### PR TITLE
fix(taskfile/eso/cert-manager): align k0s cluster auth on the shared convention

### DIFF
--- a/.taskfiles/vault/Taskfile.yaml
+++ b/.taskfiles/vault/Taskfile.yaml
@@ -5,8 +5,9 @@ version: '3'
 tasks:
   oicd-setup:
     desc: Configure k8s auth for Vault External Secrets
-    vars:
-      cluster: genmachine
+    requires:
+      vars:
+        - cluster
     cmds:
       - task: enable-vault-oidc
         vars:
@@ -14,8 +15,9 @@ tasks:
 
   eso-auth-setup:
     desc: Configure k8s auth for Vault External Secrets
-    vars:
-      cluster: genmachine
+    requires:
+      vars:
+        - cluster
     cmds:
       - task: enable-vault-k8s
         vars:
@@ -35,8 +37,9 @@ tasks:
 
   certmanager-auth-setup:
     desc: Configure k8s auth for Vault Certmanager
-    vars:
-      cluster: genmachine
+    requires:
+      vars:
+        - cluster
     cmds:
       - task: enable-vault-k8s
         vars:
@@ -84,10 +87,11 @@ tasks:
           sleep 5
         done
         kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 --decode > ca.crt
+        K8S_HOST="$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.server}')"
         TOKEN="$(kubectl get secret -n {{.namespace}} {{.service_account}} -o jsonpath='{.data.token}' | base64 -d)"
         vault write -tls-skip-verify -address={{.VAULT_ENDPOINT}}  \
           auth/{{.cluster}}-k8s/config token_reviewer_jwt="$TOKEN" \
-          kubernetes_host="https://{{.K8S_API}}:6443" \
+          kubernetes_host="$K8S_HOST" \
           kubernetes_ca_cert=@ca.crt
         rm ca.crt
     requires:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,7 +17,6 @@ vars:
   VAULT_ENDPOINT: 'https://vault.k0s-fullstack.fredcorp.com'
   AUTHENTIK_ENDPOINT_GENMACHINE: 'https://authentik.talos-genmachine.fredcorp.com'
   AUTHENTIK_ENDPOINT_BEELINK: 'https://authentik.k0s-fullstack.fredcorp.com'
-  K8S_API: 'talos-cluster.genmachine.fredcorp.com'
   MINIO_API: 'minio-api.talos-genmachine.fredcorp.com'
 
 includes:

--- a/gitops/manifests/cert-manager/k0s/templates/clusterIssuer.yaml
+++ b/gitops/manifests/cert-manager/k0s/templates/clusterIssuer.yaml
@@ -47,10 +47,10 @@ spec:
       name: root-ca-chain
     auth:
       kubernetes:
-        mountPath: /v1/auth/kubernetes
-        role: certmanager-vault-auth-k0s
+        mountPath: /v1/auth/beelink-k8s
+        role: certmanager
         secretRef:
-          name: certmanager-vault-auth-k0s
+          name: certmanager-auth
           key: token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,18 +63,18 @@ roleRef:
   name: system:auth-delegator
 subjects:
   - kind: ServiceAccount
-    name: certmanager-vault-auth-k0s
+    name: certmanager-auth
     namespace: cert-manager
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: certmanager-vault-auth-k0s
+  name: certmanager-auth
 ---
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/service-account-token
 metadata:
-  name: certmanager-vault-auth-k0s
+  name: certmanager-auth
   annotations:
-    kubernetes.io/service-account.name: 'certmanager-vault-auth-k0s'
+    kubernetes.io/service-account.name: 'certmanager-auth'

--- a/gitops/manifests/external-secrets/beelink/templates/clusterSecretStore.yaml
+++ b/gitops/manifests/external-secrets/beelink/templates/clusterSecretStore.yaml
@@ -16,8 +16,8 @@ spec:
         key: fredcorp-ca-chain.pem
       auth:
         kubernetes:
-          mountPath: kubernetes
-          role: external-secrets
+          mountPath: beelink-k8s
+          role: eso
           serviceAccountRef:
             name: eso-auth
             namespace: external-secrets


### PR DESCRIPTION
## Summary

Three-part fix that unblocks `task vault:eso-auth-setup cluster=beelink` / `task vault:certmanager-auth-setup cluster=beelink` and aligns the **k0s (beelink)** cluster auth wiring on the same convention already used by **genmachine** (`<cluster>-k8s` mount path, `certmanager`/`eso` roles, `certmanager-auth` / `eso-auth` SA names).

- **taskfile**: `vars: { cluster: genmachine }` at task level was winning over the CLI value in Taskfile v3, so `cluster=beelink` was silently ignored. Replaced with `requires: vars: [cluster]` at entry tasks, and made `kubernetes_host` extract dynamically from the current `kubectl` context instead of the hardcoded `K8S_API` root var (now removed). Calling the task without `cluster=` now fails fast instead of quietly targeting `genmachine`.
- **external-secrets (beelink)**: ClusterSecretStore was wired to `mountPath: kubernetes` / `role: external-secrets`, not matching the Vault mount the taskfile creates. Aligned on `beelink-k8s` / `eso` like the genmachine manifest.
- **cert-manager (k0s)**: ClusterIssuer and its companion SA/Secret were named `certmanager-vault-auth-k0s` with `mountPath: /v1/auth/kubernetes`, so `task vault:certmanager-auth-setup` was hanging on *ServiceAccount certmanager-auth not found*. Renamed SA/Secret to `certmanager-auth`, role to `certmanager`, mountPath to `/v1/auth/beelink-k8s`.

## Test plan

- [ ] `task vault:eso-auth-setup cluster=beelink` (kubectl context on k0s) configures `auth/beelink-k8s/` end-to-end
- [ ] `task vault:certmanager-auth-setup cluster=beelink` finds SA `certmanager-auth` and creates the `certmanager` role
- [ ] `task vault:eso-auth-setup` (no cluster arg) fails with the `requires: vars` message instead of silently using `genmachine`
- [ ] ArgoCD sync of `external-secrets-beelink` and `cert-manager-k0s` applies the renamed manifests cleanly
- [ ] `ClusterSecretStore/admin` reaches `Ready=True`
- [ ] `ClusterIssuer/fredcorp-ca` reaches `Ready=True`
- [ ] Same tasks against `cluster=genmachine` still pass (no regression on the existing cluster)

## Commits

- `fix(taskfile): allow cluster override via CLI in vault auth setup`
- `fix(external-secrets): align beelink ClusterSecretStore with cluster/role convention`
- `fix(cert-manager): align k0s ClusterIssuer naming with taskfile convention`