### PR TITLE
fix(argocd): pin numeric UID on dex-server for non-root check

### DIFF
--- a/gitops/bootstrap/genmachine/genmachine-values.yaml
+++ b/gitops/bootstrap/genmachine/genmachine-values.yaml
@@ -111,6 +111,17 @@ argo-cd:
       repository: ghcr.io/dexidp/dex
       tag: v2.45.1
       imagePullPolicy: IfNotPresent
+    containerSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
     pdb:
       enabled: true
       maxUnavailable: 1


### PR DESCRIPTION
## Summary
- After PR #1407, ArgoCD on genmachine rolled forward to v3.3.7 / dex v2.45.1.
- The dex v2.45.1 image Dockerfile declares `USER dex` (non-numeric). With the container-level `runAsNonRoot: true` that the chart sets by default, kubelet refuses to verify non-root-ness and the pod fails with:
  ```
  Error: container has runAsNonRoot and image has non-numeric user (dex), cannot verify user is non-root
  ```
- Pin `runAsUser`/`runAsGroup` to `1001` (the dex user/group UID inside the image) via `dex.containerSecurityContext`. All other hardening bits stay identical to the chart default.

## Test plan
- [ ] Merge and let ArgoCD reconcile the bootstrap app on genmachine.
- [ ] `kubectl -n argocd get pod -l app.kubernetes.io/name=argocd-dex-server` reaches `Running 1/1`.
- [ ] `kubectl -n argocd logs -l app.kubernetes.io/name=argocd-dex-server` shows connector `authentik` initialised without errors.
- [ ] Login flow via Authentik works on `https://argocd.talos-genmachine.fredcorp.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)