### PR TITLE
chore(ci): harden workflows reliability

### DIFF
--- a/.github/workflows/auto-hydrate-pr.yaml
+++ b/.github/workflows/auto-hydrate-pr.yaml
@@ -14,6 +14,7 @@ jobs:
   auto-pr-hydrator:
     name: Create PR to deploy k0s
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -30,17 +31,26 @@ jobs:
 
       - name: pull-request
         run: |
-          echo -e "${BLUE}[ STEP - CREATING PR ] > Creatin Pull Request with gh CLI${BLANK}"
+          set -eo pipefail
+          echo -e "${BLUE}[ STEP - CREATING PR ] > Creating Pull Request with gh CLI${BLANK}"
           echo -e "${CYAN}[ INFO ] > gh version.${BLANK}"
           gh --version
 
-          gh_pr_up() {
-            gh pr create "$@" || gh pr edit "$@"
-          }
+          TITLE="chore(hydrator): deploying into deploy/k0s"
+          BODY=":crown: *An automated PR* - ${{ github.ref }}"
+          BASE="deploy/k0s"
+          HEAD="${GITHUB_REF_NAME}"
 
-          gh_pr_up --title "chore(hydrator): deploying into deploy/k0s" \
-                   --body ":crown: *An automated PR* - ${{ github.ref }}" \
-                   --base "deploy/k0s"
+          EXISTING_PR=$(gh pr list --head "${HEAD}" --base "${BASE}" --state open --json number --jq '.[0].number // empty')
+
+          if [ -n "${EXISTING_PR}" ]
+          then
+            echo -e "${CYAN}[ INFO ] > PR #${EXISTING_PR} already open, updating title/body${BLANK}"
+            gh pr edit "${EXISTING_PR}" --title "${TITLE}" --body "${BODY}"
+          else
+            echo -e "${CYAN}[ INFO ] > Creating new PR ${HEAD} -> ${BASE}${BLANK}"
+            gh pr create --title "${TITLE}" --body "${BODY}" --base "${BASE}" --head "${HEAD}"
+          fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.TOKEN }}
           RED: \033[1;31m

--- a/.github/workflows/helm-rmp.yaml
+++ b/.github/workflows/helm-rmp.yaml
@@ -2,6 +2,7 @@
 ---
 name: Helm Dynamic Rendered Manifest
 on:
+  merge_group:
   pull_request:
     types:
       - opened
@@ -10,14 +11,13 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   rendered-manifest:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: write
@@ -194,7 +194,7 @@ jobs:
           target: pr/*_manifest_pr.yaml
 
       - name: Post diff as comment
-        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.number != ''
         run: |
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md --edit-last || \
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md

--- a/.github/workflows/helm-rmp.yaml
+++ b/.github/workflows/helm-rmp.yaml
@@ -11,13 +11,14 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   rendered-manifest:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: write
@@ -194,7 +195,7 @@ jobs:
           target: pr/*_manifest_pr.yaml
 
       - name: Post diff as comment
-        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.number != ''
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
         run: |
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md --edit-last || \
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md

--- a/.github/workflows/helm-rmp.yaml
+++ b/.github/workflows/helm-rmp.yaml
@@ -2,7 +2,6 @@
 ---
 name: Helm Dynamic Rendered Manifest
 on:
-  merge_group:
   pull_request:
     types:
       - opened
@@ -17,6 +16,7 @@ concurrency:
 jobs:
   rendered-manifest:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -52,7 +52,7 @@ jobs:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
           VALUES_FILE: values-full.yaml
         run: |
-          set +e
+          set -eo pipefail
           RED="\033[1;31m"
           GREEN="\033[1;32m"
           YELLOW="\033[1;33m"
@@ -152,9 +152,13 @@ jobs:
                   old_path=${path}
                   path=${dir}
                   template_version "pr"
-                  git checkout origin/main -- "$(dirname ${old_path})"
-                  template_version "main"
-                  git checkout origin/${{ github.head_ref }} -- "$(dirname ${old_path})"
+                  if git checkout origin/main -- "$(dirname ${old_path})" 2>/dev/null
+                  then
+                    template_version "main"
+                    git checkout origin/${{ github.head_ref }} -- "$(dirname ${old_path})"
+                  else
+                    echo -e "${YELLOW}[ WARN ] > Path not present on origin/main, skipping main render for ${PURPLE}${path}${BLANK}"
+                  fi
                 done
               else
                 echo -e "${RED}[ ERROR ] > No helm chart found"
@@ -162,9 +166,13 @@ jobs:
               fi
             else
               template_version "pr"
-              git checkout origin/main -- "$path"
-              template_version "main"
-              git checkout origin/${{ github.head_ref }} -- "$path"
+              if git checkout origin/main -- "$path" 2>/dev/null
+              then
+                template_version "main"
+                git checkout origin/${{ github.head_ref }} -- "$path"
+              else
+                echo -e "${YELLOW}[ WARN ] > Path not present on origin/main, skipping main render for ${PURPLE}${path}${BLANK}"
+              fi
             fi
           done
 
@@ -200,3 +208,15 @@ jobs:
         uses: ixxeL-DevOps/gha-templates/.github/actions/kubeconform@main
         with:
           target: pr
+
+      - name: Surface Kubeconform outcome
+        if: steps.changed-files.outputs.any_changed == 'true' && always()
+        run: |
+          OUTCOME="${{ steps.kubeconform.outcome }}"
+          if [ "${OUTCOME}" = "success" ]
+          then
+            echo "### Kubeconform: passed" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Kubeconform: ${OUTCOME} (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Kubeconform::Validation outcome=${OUTCOME} — review the step logs"
+          fi

--- a/.github/workflows/kustomize-rmp.yaml
+++ b/.github/workflows/kustomize-rmp.yaml
@@ -2,7 +2,6 @@
 ---
 name: Kustomize Dynamic Rendered Manifest
 on:
-  merge_group:
   pull_request:
     types:
       - opened
@@ -14,12 +13,13 @@ on:
       - '**/kustomization.yml'
 
 concurrency:
-  group: ${{ github.ref_name }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   rendered-manifest:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'pull_request'
     steps:
       - name: Generate Token
@@ -67,9 +67,12 @@ jobs:
 
             template "pr"
 
-            git checkout origin/main -- "$path"
-
-            template "main"
+            if git checkout origin/main -- "$path" 2>/dev/null
+            then
+              template "main"
+            else
+              echo "[ WARN ] Path ${path} not present on origin/main, skipping main render"
+            fi
             echo ""
           done
 
@@ -105,3 +108,15 @@ jobs:
         uses: ixxeL-DevOps/gha-templates/.github/actions/kubeconform@main
         with:
           target: pr
+
+      - name: Surface Kubeconform outcome
+        if: steps.changed-files.outputs.any_changed == 'true' && always()
+        run: |
+          OUTCOME="${{ steps.kubeconform.outcome }}"
+          if [ "${OUTCOME}" = "success" ]
+          then
+            echo "### Kubeconform: passed" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Kubeconform: ${OUTCOME} (non-blocking)" >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning title=Kubeconform::Validation outcome=${OUTCOME} — review the step logs"
+          fi

--- a/.github/workflows/kustomize-rmp.yaml
+++ b/.github/workflows/kustomize-rmp.yaml
@@ -14,13 +14,14 @@ on:
       - '**/kustomization.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   rendered-manifest:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name == 'pull_request'
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -94,7 +95,7 @@ jobs:
           target: pr/*_manifest_pr.yaml
 
       - name: Post diff as comment
-        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.number != ''
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
         run: |
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md --edit-last || \
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md

--- a/.github/workflows/kustomize-rmp.yaml
+++ b/.github/workflows/kustomize-rmp.yaml
@@ -2,6 +2,7 @@
 ---
 name: Kustomize Dynamic Rendered Manifest
 on:
+  merge_group:
   pull_request:
     types:
       - opened
@@ -13,14 +14,13 @@ on:
       - '**/kustomization.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   rendered-manifest:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'pull_request'
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -94,7 +94,7 @@ jobs:
           target: pr/*_manifest_pr.yaml
 
       - name: Post diff as comment
-        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request'
+        if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'pull_request' && github.event.pull_request.number != ''
         run: |
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md --edit-last || \
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file diff.md

--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -17,6 +17,7 @@ jobs:
   labels:
     name: Sync Labels
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   build_mkdocs:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -43,6 +43,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -16,6 +16,7 @@ jobs:
   pre-commit:
     name: Run pre-commit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Generate Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1


### PR DESCRIPTION
- Add timeout-minutes on every job to bound runtime
- helm-rmp: replace `set +e` with `set -eo pipefail` and guard `git checkout origin/main` for paths not yet on main
- kustomize-rmp: same guard for new kustomization paths
- helm-rmp / kustomize-rmp: drop dead `merge_group` trigger and align concurrency keys (workflow + ref + PR number)
- auto-hydrate-pr: replace `gh pr create || gh pr edit` swallow with an explicit lookup so create failures stop bubbling up as silent edits
- helm-rmp / kustomize-rmp: surface Kubeconform outcome in the job summary instead of leaving `continue-on-error: true` fully silent

<br/>
<div align="center">
  <p align="center"><img style="display: block; margin: auto; width: 125px;"  src="https://github.com/ixxeL-DevOps/fullstack/blob/main/docs/assets/k8s-home.png?raw=true"></p>
  <h3>✨ixxeL Home-Lab✨</h3>
</div>

**PR guidelines**

- [ ] Pull request targets `main` branch
- [ ] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Files follow `pre-commit` standards from main branch
