### PR TITLE
feat(adguard): deploy adguardhome-sync for cross-cluster config sync

### DIFF
--- a/gitops/manifests/adguard/genmachine/templates/adguardhome-sync.yaml
+++ b/gitops/manifests/adguard/genmachine/templates/adguardhome-sync.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adguardhome-sync-config
+  namespace: adguard
+data:
+  config.yaml: |
+    cron: "*/2 * * * *"
+    runOnStart: true
+    logTimestamp: false
+    origin:
+      url: http://adguard-adguard-home-http:80
+      apiPath: /control
+    replicas:
+      - url: https://adguard.k0s-fullstack.fredcorp.com
+        insecureskipverify: true
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: adguardhome-sync-credentials
+  namespace: adguard
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: admin
+    kind: ClusterSecretStore
+  target:
+    name: adguardhome-sync-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      engineVersion: v2
+      data:
+        ADGUARDHOME_SYNC_ORIGIN_USERNAME: '{{ "{{" }}.username{{ "}}" }}'
+        ADGUARDHOME_SYNC_ORIGIN_PASSWORD: '{{ "{{" }}.password{{ "}}" }}'
+        ADGUARDHOME_SYNC_REPLICA1_USERNAME: '{{ "{{" }}.username{{ "}}" }}'
+        ADGUARDHOME_SYNC_REPLICA1_PASSWORD: '{{ "{{" }}.password{{ "}}" }}'
+  data:
+    - secretKey: username
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        key: adguard/credentials
+        property: username
+    - secretKey: password
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        key: adguard/credentials
+        property: password
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adguardhome-sync
+  namespace: adguard
+  labels:
+    app.kubernetes.io/name: adguardhome-sync
+    app.kubernetes.io/instance: adguard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: adguardhome-sync
+      app.kubernetes.io/instance: adguard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: adguardhome-sync
+        app.kubernetes.io/instance: adguard
+    spec:
+      priorityClassName: infra-apps-priority
+      containers:
+        - name: adguardhome-sync
+          # renovate: datasource=github-releases depName=bakito/adguardhome-sync
+          image: ghcr.io/bakito/adguardhome-sync:v0.9.0
+          args:
+            - run
+          envFrom:
+            - secretRef:
+                name: adguardhome-sync-credentials
+          env:
+            - name: ADGUARDHOME_SYNC_CONFIG
+              value: /config/config.yaml
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: adguardhome-sync-config


### PR DESCRIPTION
## Summary

- Deploys [bakito/adguardhome-sync](https://github.com/bakito/adguardhome-sync) `v0.9.0` in the `adguard` namespace on genmachine
- Existing AdGuard Home deployment is **untouched** (still 3 replicas, same PVC)
- Sync runs every 2 minutes: genmachine adguard (origin) → beelink adguard `adguard.k0s-fullstack.fredcorp.com` (replica)
- Synced: DNS rewrites, filters, blocked services, upstream DNS config

## New resources

| Resource | Kind | Purpose |
|---|---|---|
| `adguardhome-sync-config` | ConfigMap | Sync config (origin/replica URLs, cron) |
| `adguardhome-sync-credentials` | ExternalSecret | Fetches plaintext credentials from Vault |
| `adguardhome-sync` | Deployment | Runs the sync loop |

## Prerequisite: Vault secret

The ExternalSecret pulls from Vault path `adguard/credentials`. This key must be populated before ArgoCD syncs:

```
vault kv put adguard/credentials username=admin password=<plaintext-admin-password>
```

## Test plan

- [ ] Vault key `adguard/credentials` populated with plaintext admin password
- [ ] `adguardhome-sync-credentials` Secret created successfully by ExternalSecret
- [ ] `adguardhome-sync` pod Running
- [ ] Logs show successful sync: `sync completed`
- [ ] DNS rewrite change on genmachine propagates to beelink within ~2 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)