### PR TITLE
chore(renovate): one PR per minor for Kubernetes and Talos upgrades

### DIFF
--- a/.renovate/package-rules.json
+++ b/.renovate/package-rules.json
@@ -17,6 +17,15 @@
         "description": ["Don't pin digests for managers that don't need a digest"],
         "matchManagers": ["helmfile"],
         "pinDigests": false
+      },
+      {
+        "description": ["One PR per minor for Kubernetes and Talos — never jump multiple minors at once"],
+        "matchPackageNames": [
+          "ghcr.io/siderolabs/kubelet",
+          "ghcr.io/siderolabs/installer",
+          "registry.k8s.io/kubectl"
+        ],
+        "separateMultipleMinor": true
       }
     ]
   }


### PR DESCRIPTION
## Summary

- Adds `separateMultipleMinor: true` for `siderolabs/kubelet`, `siderolabs/installer` and `registry.k8s.io/kubectl`
- Renovate now proposes only the **next minor** instead of jumping to the latest (e.g. 1.33→1.34, not 1.33→1.36)
- After each minor is merged, Renovate opens the next one automatically
- The existing group rule (`system-upgrade-controller-genmachine`) is preserved — the 3 packages still move together in the same PR, just capped to one minor at a time

## Before / After

| Before | After |
|---|---|
| One PR: `v1.33.4` → `v1.36.0` | PR 1: `v1.33.x` → `v1.34.x` |
| | PR 2 (after merge): `v1.34.x` → `v1.35.x` |
| | PR 3 (after merge): `v1.35.x` → `v1.36.x` |

## Why

Kubernetes and Talos minor upgrades are non-trivial cluster operations. Skipping multiple minors at once makes it harder to identify regressions and doesn't match the official upgrade guidance (upgrade one minor at a time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)