### PR TITLE
feat(github): add system upgrade and tuppr labels

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -124,6 +124,23 @@
   color: '4E0DA8'
   description: >-
     Changes made to System Upgrade Controller application
+- name: app/tuppr
+  color: '39FF14'
+  description: >-
+    Changes made to tuppr upgrade controller application
+# System
+- name: system/cluster
+  color: 'FF00FF'
+  description: >-
+    Cluster-level upgrade (Talos or Kubernetes)
+- name: system/talos
+  color: 'FF1493'
+  description: >-
+    Talos OS upgrade
+- name: system/kubernetes
+  color: '00CFFF'
+  description: >-
+    Kubernetes upgrade
 - name: app/vault
   color: '0B0D06'
   description: >-


### PR DESCRIPTION
## Summary

- Add `app/tuppr` label (`#39FF14` neon green) for tuppr controller upgrades
- Add `system/cluster` label (`#FF00FF` magenta) for cluster-level upgrade PRs
- Add `system/talos` label (`#FF1493` hot pink) for Talos OS upgrade PRs
- Add `system/kubernetes` label (`#00CFFF` electric cyan) for Kubernetes upgrade PRs

These labels are referenced in `.renovate/cluster.json` by the Renovate package rules introduced in the tuppr migration PR.

## Test plan

- [ ] Labels are created by the label-sync workflow after merge
- [ ] Renovate PRs for tuppr/talos/kubernetes upgrades pick up the correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)