### PR TITLE
feat(vault): configure transit auto-unseal cross-cluster

### DIFF
--- a/gitops/manifests/vault/beelink/beelink-values.yaml
+++ b/gitops/manifests/vault/beelink/beelink-values.yaml
@@ -32,6 +32,11 @@ vault:
     #   whenDeleted: Retain
     #   whenScaled: Retain
 
+    extraSecretEnvironmentVars:
+      - envName: TRANSIT_UNSEAL_TOKEN
+        secretName: vault-transit-token
+        secretKey: token
+
     ingress:
       enabled: true
       annotations:
@@ -62,6 +67,13 @@ vault:
       }
       storage "file" {
         path = "/vault/data"
+      }
+      seal "transit" {
+        address         = "https://vault.talos-genmachine.fredcorp.com"
+        token           = "$TRANSIT_UNSEAL_TOKEN"
+        key_name        = "unseal-beelink"
+        mount_path      = "transit/"
+        tls_skip_verify = "true"
       }
 
   ui:

--- a/gitops/manifests/vault/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/vault/genmachine/genmachine-values.yaml
@@ -12,6 +12,11 @@ vault:
       storageClass: proxmox-retain
       accessMode: ReadWriteOnce
 
+    extraSecretEnvironmentVars:
+      - envName: TRANSIT_UNSEAL_TOKEN
+        secretName: vault-transit-token
+        secretKey: token
+
     ingress:
       enabled: true
       annotations:
@@ -29,3 +34,24 @@ vault:
         - secretName: vault-tls-cert
           hosts:
             - vault.talos-genmachine.fredcorp.com
+
+  standalone:
+    enabled: true
+    config: |-
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "file" {
+        path = "/vault/data"
+      }
+      seal "transit" {
+        address         = "https://vault.k0s-fullstack.fredcorp.com"
+        token           = "$TRANSIT_UNSEAL_TOKEN"
+        key_name        = "unseal-genmachine"
+        mount_path      = "transit/"
+        tls_skip_verify = "true"
+      }


### PR DESCRIPTION
## Summary

- **beelink** Vault → auto-unseals via **genmachine** Transit engine (`unseal-beelink` key)
- **genmachine** Vault → auto-unseals via **beelink** Transit engine (`unseal-genmachine` key)

Transit token injected at pod startup from a `vault-transit-token` K8s secret (namespace `vault`) — **not** via ExternalSecrets, intentionally, since Vault isn't unsealed yet at that point.

## Pre-requisites before merging

On each cluster, the K8s secret must exist (or use the new task to create it):
\`\`\`bash
task vault:unseal-secret:genmachine   # reads from genmachine Vault KV
task vault:unseal-secret:beelink      # reads from beelink Vault KV
\`\`\`

## Post-merge migration (one-time per Vault)

After ArgoCD syncs, each Vault will restart sealed. Run once to migrate from Shamir → Transit:
\`\`\`bash
# On beelink
VAULT_ADDR=https://vault.k0s-fullstack.fredcorp.com vault operator unseal -migrate <shamir_key>

# On genmachine
VAULT_ADDR=https://vault.talos-genmachine.fredcorp.com vault operator unseal -migrate <shamir_key>
\`\`\`

After migration, all future restarts auto-unseal without intervention.

## Circular dependency note

If **both** Vaults restart simultaneously, neither can auto-unseal the other. Unseal the first one manually (one key), the second recovers on its own.

## Test plan

- [ ] `vault-transit-token` secret exists in `vault` namespace on both clusters
- [ ] ArgoCD sync succeeds for both Vault apps
- [ ] `vault operator unseal -migrate` completes on both instances
- [ ] Pod restart → Vault unseals automatically (verify via `vault status`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)