### PR TITLE
fix(vault): move seal config to server.standalone.config

### DIFF
--- a/gitops/manifests/vault/beelink/beelink-values.yaml
+++ b/gitops/manifests/vault/beelink/beelink-values.yaml
@@ -37,6 +37,26 @@ vault:
         secretName: vault-transit-token
         secretKey: token
 
+    standalone:
+      config: |-
+        ui = true
+
+        listener "tcp" {
+          tls_disable = 1
+          address = "[::]:8200"
+          cluster_address = "[::]:8201"
+        }
+        storage "file" {
+          path = "/vault/data"
+        }
+        seal "transit" {
+          address         = "https://vault.talos-genmachine.fredcorp.com"
+          token           = "$TRANSIT_UNSEAL_TOKEN"
+          key_name        = "unseal-beelink"
+          mount_path      = "transit/"
+          tls_skip_verify = "true"
+        }
+
     ingress:
       enabled: true
       annotations:
@@ -57,24 +77,6 @@ vault:
 
   standalone:
     enabled: true
-    config: |-
-      ui = true
-
-      listener "tcp" {
-        tls_disable = 1
-        address = "[::]:8200"
-        cluster_address = "[::]:8201"
-      }
-      storage "file" {
-        path = "/vault/data"
-      }
-      seal "transit" {
-        address         = "https://vault.talos-genmachine.fredcorp.com"
-        token           = "$TRANSIT_UNSEAL_TOKEN"
-        key_name        = "unseal-beelink"
-        mount_path      = "transit/"
-        tls_skip_verify = "true"
-      }
 
   ui:
     enabled: true

--- a/gitops/manifests/vault/beelink/beelink-values.yaml
+++ b/gitops/manifests/vault/beelink/beelink-values.yaml
@@ -38,6 +38,7 @@ vault:
         secretKey: token
 
     standalone:
+      enabled: true
       config: |-
         ui = true
 
@@ -74,9 +75,6 @@ vault:
         - secretName: vault-tls-cert
           hosts:
             - vault.k0s-fullstack.fredcorp.com
-
-  standalone:
-    enabled: true
 
   ui:
     enabled: true

--- a/gitops/manifests/vault/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/vault/genmachine/genmachine-values.yaml
@@ -17,6 +17,26 @@ vault:
         secretName: vault-transit-token
         secretKey: token
 
+    standalone:
+      config: |-
+        ui = true
+
+        listener "tcp" {
+          tls_disable = 1
+          address = "[::]:8200"
+          cluster_address = "[::]:8201"
+        }
+        storage "file" {
+          path = "/vault/data"
+        }
+        seal "transit" {
+          address         = "https://vault.k0s-fullstack.fredcorp.com"
+          token           = "$TRANSIT_UNSEAL_TOKEN"
+          key_name        = "unseal-genmachine"
+          mount_path      = "transit/"
+          tls_skip_verify = "true"
+        }
+
     ingress:
       enabled: true
       annotations:
@@ -34,24 +54,3 @@ vault:
         - secretName: vault-tls-cert
           hosts:
             - vault.talos-genmachine.fredcorp.com
-
-  standalone:
-    enabled: true
-    config: |-
-      ui = true
-
-      listener "tcp" {
-        tls_disable = 1
-        address = "[::]:8200"
-        cluster_address = "[::]:8201"
-      }
-      storage "file" {
-        path = "/vault/data"
-      }
-      seal "transit" {
-        address         = "https://vault.k0s-fullstack.fredcorp.com"
-        token           = "$TRANSIT_UNSEAL_TOKEN"
-        key_name        = "unseal-genmachine"
-        mount_path      = "transit/"
-        tls_skip_verify = "true"
-      }

--- a/gitops/manifests/vault/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/vault/genmachine/genmachine-values.yaml
@@ -18,6 +18,7 @@ vault:
         secretKey: token
 
     standalone:
+      enabled: true
       config: |-
         ui = true
 


### PR DESCRIPTION
## Problem

PR #1478 added the `seal "transit"` block under `standalone.config` (top-level), but the Vault Helm chart expects it under `server.standalone.config`. The top-level `standalone.config` is silently ignored — the chart always used its built-in default HCL, which is why the ConfigMap never contained the seal block and `vault operator unseal -migrate` returned *"no migration seal found"*.

This was a pre-existing misconfiguration (the `standalone.config` in `common-values.yaml` was also never applied), but it had no visible impact since the chart defaults matched the intended config exactly.

## Fix

Move `seal "transit"` + full HCL config into `vault.server.standalone.config` (the path actually read by the Helm chart template) for both clusters.

## Test plan

- [ ] ArgoCD sync → `vault-config` ConfigMap contains the `seal "transit"` block
- [ ] Pod restarts with `Seal Type: transit` in its startup logs
- [ ] `vault operator unseal -migrate <shamir_key>` succeeds on both instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)