### PR TITLE
feat(fstrim): weekly SSD fstrim CronJob for Talos nodes

### DIFF
--- a/gitops/core/apps/genmachine/system/fstrim.yaml
+++ b/gitops/core/apps/genmachine/system/fstrim.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: fstrim
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: .;../common
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: 'https://github.com/ixxeL-DevOps/fullstack.git'
+        revision: main
+        directories:
+          - path: 'gitops/manifests/fstrim/*'
+            exclude: false
+          - path: 'gitops/manifests/fstrim/common'
+            exclude: true
+  template:
+    metadata:
+      name: 'fstrim-{{ .path.basenameNormalized }}'
+      annotations:
+        argocd.argoproj.io/manifest-generate-paths: .;../common
+    spec:
+      project: infra-tools
+      destination:
+        name: '{{ .path.basenameNormalized }}'
+        namespace: kube-system
+      sources:
+        - path: 'gitops/manifests/fstrim/{{ .path.basenameNormalized }}'
+          repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+          targetRevision: main
+          helm:
+            releaseName: fstrim
+            valueFiles:
+              - $values/gitops/manifests/fstrim/common/common-values.yaml
+              - $values/gitops/manifests/fstrim/{{ .path.basenameNormalized }}/{{ .path.basenameNormalized }}-values.yaml
+            ignoreMissingValueFiles: true
+        - repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+          targetRevision: main
+          ref: values
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - Validate=true
+          - PruneLast=true
+          - RespectIgnoreDifferences=true
+          - Replace=false
+          - ApplyOutOfSyncOnly=true
+          - CreateNamespace=true
+          - ServerSideApply=true
+        retry:
+          limit: 6
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/gitops/manifests/fstrim/common/common-values.yaml
+++ b/gitops/manifests/fstrim/common/common-values.yaml
@@ -1,0 +1,10 @@
+---
+fstrim:
+  schedule: "0 2 * * 0"
+  image:
+    repository: alpine
+    tag: "3.21"
+    pullPolicy: IfNotPresent
+  nodeCount: 3
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3

--- a/gitops/manifests/fstrim/genmachine/Chart.yaml
+++ b/gitops/manifests/fstrim/genmachine/Chart.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v2
+name: fstrim
+version: 1.0.0
+description: Weekly fstrim CronJob for SSD health on Talos nodes

--- a/gitops/manifests/fstrim/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/fstrim/genmachine/genmachine-values.yaml
@@ -1,0 +1,3 @@
+---
+fstrim:
+  nodeCount: 3

--- a/gitops/manifests/fstrim/genmachine/templates/cronjob.yaml
+++ b/gitops/manifests/fstrim/genmachine/templates/cronjob.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: fstrim
+  namespace: kube-system
+spec:
+  schedule: {{ .Values.fstrim.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.fstrim.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.fstrim.failedJobsHistoryLimit }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      completions: {{ .Values.fstrim.nodeCount }}
+      parallelism: {{ .Values.fstrim.nodeCount }}
+      completionMode: Indexed
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          hostPID: true
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: DoNotSchedule
+              labelSelector:
+                matchLabels:
+                  job-name: fstrim
+          tolerations:
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoExecute
+          containers:
+            - name: fstrim
+              image: {{ .Values.fstrim.image.repository }}:{{ .Values.fstrim.image.tag }}
+              imagePullPolicy: {{ .Values.fstrim.image.pullPolicy }}
+              command:
+                - nsenter
+                - --target
+                - "1"
+                - --mount
+                - --
+                - fstrim
+                - -av
+              securityContext:
+                privileged: true
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  memory: 64Mi


### PR DESCRIPTION
## Summary

- Adds a Helm chart (`gitops/manifests/fstrim/`) deploying a weekly `CronJob` that runs `fstrim -av` on all 3 genmachine Talos nodes
- Uses `nsenter --target 1 --mount` to reach the host mount namespace (avoids messy `hostPath` volume mounts); requires `hostPID: true` and `privileged: true`
- `completionMode: Indexed` + `topologySpreadConstraints` (maxSkew=1) guarantees exactly one pod per node per run
- Scheduled Sunday at 02:00 (`0 2 * * 0`); `concurrencyPolicy: Forbid` prevents overlap
- ArgoCD ApplicationSet in `gitops/core/apps/genmachine/system/fstrim.yaml`, project `infra-tools`, namespace `kube-system`

## Test plan

- [ ] ArgoCD syncs `fstrim-genmachine` application cleanly
- [ ] Manual trigger: `kubectl create job -n kube-system fstrim-test --from=cronjob/fstrim`
- [ ] Verify 3 pods scheduled, one per node: `kubectl get pods -n kube-system -l job-name=fstrim-test -o wide`
- [ ] Check logs show fstrim output for each node: `kubectl logs -n kube-system -l job-name=fstrim-test`

Closes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)