### PR TITLE
docs(ai-context): add comprehensive AI context documentation suite

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,62 @@
+# Homelab Repository Context
+
+GitOps-managed Kubernetes homelab using ArgoCD, Talos and k0s.
+
+## Read First
+
+1. **@docs/ai-context/README.md** - Overview and navigation
+2. **@docs/ai-context/Ethos.md** - Documentation philosophy
+3. **@docs/ai-context/ARCHITECTURE.md** - System architecture
+4. **@docs/ai-context/CONVENTIONS.md** - Coding standards
+
+## Documentation
+
+### System Context
+
+- @docs/ai-context/ARCHITECTURE.md - Architecture, capsules, patterns
+- @docs/ai-context/NETWORKING.md - Traffic flows, DNS, gateways, OIDC
+- @docs/ai-context/DOMAIN.md - Rules, state machines, glossary
+- @docs/ai-context/WORKFLOWS.md - How to deploy, update, troubleshoot
+- @docs/ai-context/TOOLS.md - CLI commands
+- @docs/ai-context/CONVENTIONS.md - Naming, structure, style
+
+### Writing Guides
+
+- @docs/ai-context/Ethos.md - Hard rules, guidance, values
+- @docs/ai-context/PLANNING.md - Collaborative planning lifecycle
+- @docs/ai-context/writing-documentation.md - Wisdom triggers
+- @docs/ai-context/writing-capsules.md - Capsule format
+- @docs/ai-context/mermaid-diagram-guide.md - Diagram rules
+
+## Critical Invariants
+
+### Clusters: Location of Source
+
+There are two independent clusters:
+
+genmachine(Talos): each `genmachine` or Talos directory relate to this cluster. Root at @infra/talos.
+beelink(k0s): each `beelink` or k0s directory relate to this cluster. Root at @infra/k0s.
+
+The only shared code is the `common` directories which host shared values for applies Helm deployments.
+Except from that the clusters do not share code. When making changes, it is important
+to know which cluster is being worked on. Make sure to know this in advance
+of any planning or changes.
+
+### Capsule: GitOpsReconciliation
+
+**Invariant**: Cluster state converges to match Git; ArgoCD reverts manual changes.
+
+## Directory Structure
+
+```
+infra/                  # Root directory for clusters configuration and boostrap
+gitops/                 # Root directory for all deployed manifests
+gitops/bootstrap        # ArgoCD installation directory
+gitops/core             # ArgoCD CRs manifests (ApplicationSet, AppProject, VCS secrets...)
+gitops/manifests        # Helm or plain YAML manifests to deploy applications
+```
+
+## Non-Obvious Truths
+
+- **Automated update**: Always think about automated update for versions with Renovate
+- **SOPS files**: End in `.sops.yaml`, encrypted before commit

--- a/docs/ai-context/ARCHITECTURE.md
+++ b/docs/ai-context/ARCHITECTURE.md
@@ -1,0 +1,352 @@
+---
+description: Dual-cluster GitOps architecture covering Flux reconciliation, template pipeline, routing patterns, and operational constraints
+tags: ["GitOps", "FluxReconciliation", "Jinja2Templates", "EnvoyGateway", "DualCluster", "ExternalSecrets"]
+audience: ["LLMs", "Humans"]
+categories: ["Architecture[100%]", "Reference[90%]"]
+---
+
+# Dual-Cluster Homelab Architecture
+
+## Core Pattern
+
+### Capsule: DualClusterIsolation
+
+**Invariant**
+Genmachine and Beelink clusters are independent; no shared code, separate configurations, isolated infrastructure.
+
+**Example**
+Genmachine cluster lives in `infra/talos/`; Beelink cluster lives in `infra/k0s/`; changes to one never affect the other.
+//BOUNDARY: No automatic sync between clusters; copying requires explicit manual action.
+
+**Depth**
+
+- Distinction: Not environments or branches - completely separate infrastructures
+- Trade-off: Duplicate configuration for safety vs shared code for consistency
+- NotThis: They don't share namespaces, apps, or ArgoCD state
+- Critical: Always specify which cluster when making changes
+- SeeAlso: `ClusterOrganization`, `GitOpsReconciliation`
+
+---
+
+### Capsule: GitOpsReconciliation
+
+**Invariant**
+
+- Cluster state converges to match Git; ArgoCD reverts manual changes on next sync.
+- Deployment requires a definition (`Application` or `ApplicationSet` in `gitops/core`) and a manifest (Helm chart or plain YAML in `gitops/manifests`)
+
+**Example**
+Push manifests to `gitops/manifest/cilium/genmachine/*`; ArgoCD detects within minutes; cluster deploys. `kubectl edit` gets overwritten on reconciliation.
+
+**Depth**
+
+- Distinction: GitOps is declarative (desired state in Git); `kubectl` is imperative
+- Trade-off: Consistency and auditability vs immediate manual changes
+- NotThis: `kubectl apply` bypasses GitOps and creates drift
+- Timing: ArgoCD reconciles every 3 minutes
+
+---
+
+### Capsule: ExternalSecretSync
+
+**Invariant**
+ExternalSecrets pull from HC Vault; Kubernetes secrets populate before pods can start.
+
+**Example**
+Application references `app-secret`; ExternalSecret pulls from `admin/authentik/bootstrap`; pod receives value at runtime.
+//BOUNDARY: Missing Vault entry blocks ExternalSecret sync, blocking pod startup.
+
+**Depth**
+
+- Distinction: Vault is source of truth; ExternalSecrets sync values to cluster
+- Trade-off: More indirection, but repo stays public safely and secrets centralized
+- NotThis: Hardcoding secrets in manifests defeats the pattern
+- Store: ClusterSecretStore named `admin`
+- SeeAlso: `OnePasswordIntegration`, `SecretManagement`
+
+---
+
+## Routing Patterns
+
+### Capsule: TraefikRouting
+
+**Invariant**
+
+- External/internal traffic routes via Traefik using `Ingress`.
+- Certificates are created by Cert-manager and PKI is HC Vault
+- Annotations to automate certificate creation from Cert-manager
+
+**Example**
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: fredcorp-ca
+    cert-manager.io/common-name: homarr.talos-genmachine.fredcorp.com
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/service.scheme: https
+  hosts:
+    - host: homarr.talos-genmachine.fredcorp.com
+      paths:
+        - path: /
+  tls:
+    - secretName: homarr-tls-cert
+      hosts:
+        - homarr.talos-genmachine.fredcorp.com
+```
+
+**Depth**
+
+- Distinction: Treafik for `Ingress`, Cilium for CNI
+- SeeAlso: `ExternalDNS`, `ClientTrafficPolicy`
+
+---
+
+## Directory Structure
+
+### Main Cluster
+
+```
+kubernetes/main/
+├── apps/                  # 16 namespaces, 78+ HelmReleases
+│   ├── cert-manager/
+│   ├── dbms/              # CloudNative-PG, Dragonfly, pgAdmin
+│   ├── default/
+│   ├── external-secrets/
+│   ├── flux-system/
+│   ├── home/              # Home Assistant
+│   ├── jobs/
+│   ├── kube-system/       # Cilium, CoreDNS, metrics-server
+│   ├── media/             # Plex, *arr apps, qBittorrent (14 apps)
+│   ├── network/           # Envoy Gateway, external-dns, multus
+│   ├── observability/     # Prometheus, Grafana, Loki
+│   ├── rook-ceph/         # Distributed storage
+│   ├── self-hosted/       # Homepage, WikiJS, PDF tools
+│   ├── system/            # kopia, volsync, descheduler
+│   ├── system-upgrade/
+│   └── actions-runner-system/
+├── bootstrap/             # Helmfile-based bootstrap
+│   ├── helmfile.d/
+│   └── resources.yaml.j2
+├── cluster/               # Flux cluster configuration
+├── components/            # Shared kustomize components
+│   ├── alerts/
+│   ├── app-template/
+│   ├── gatus/
+│   ├── volsync/
+│   └── zeroscaler/
+├── talos/                 # Talos OS configuration
+│   ├── nodes/             # k8s-1 through k8s-6 (.j2 templates)
+│   ├── machineconfig.yaml.j2
+│   └── talosconfig.j2
+└── .justfile             # Cluster-specific tasks
+```
+
+### Staging Cluster
+
+```
+kubernetes/staging/
+├── apps/                  # Same structure as main
+├── bootstrap/
+├── cluster/
+├── components/
+├── talos/
+└── .justfile
+```
+
+**Key Insight**: Each cluster is a complete, independent configuration. No shared code between `main/` and `staging/`.
+
+---
+
+## Namespaces (Main Cluster)
+
+| Namespace             | Purpose              | Key Apps                                                        |
+| --------------------- | -------------------- | --------------------------------------------------------------- |
+| actions-runner-system | GitHub Actions       | actions-runner-controller                                       |
+| cert-manager          | TLS certificates     | cert-manager                                                    |
+| dbms                  | Databases            | cloudnative-pg, dragonfly, pgadmin4                             |
+| default               | Test apps            | whoami                                                          |
+| external-secrets      | Secret sync          | external-secrets, onepassword-connect                           |
+| flux-system           | GitOps               | flux controllers, sources, alerts                               |
+| home                  | Home apps            | home-assistant                                                  |
+| jobs                  | Batch jobs           | CronJobs for maintenance                                        |
+| kube-system           | Core Kubernetes      | cilium, coredns, metrics-server, node-feature-discovery         |
+| media                 | Media management     | plex, sonarr, radarr, bazarr, immich, seerr, prowlarr (14 apps) |
+| network               | Networking           | envoy-gateway, external-dns, cloudflare-tunnel, multus          |
+| observability         | Monitoring           | prometheus, grafana, loki, alloy, victoria-logs                 |
+| rook-ceph             | Distributed storage  | rook-ceph-cluster, operators                                    |
+| self-hosted           | Self-hosted services | homepage, wikijs, shlink, pdf-tools, change-detection           |
+| system                | System tools         | kopia, volsync, descheduler, reloader, spegel                   |
+| system-upgrade        | OS updates           | system-upgrade-controller                                       |
+
+---
+
+## Cluster Comparison
+
+| Aspect             | Talos Cluster                     | Staging Cluster           |
+| ------------------ | --------------------------------- | ------------------------- |
+| **Infrastructure** | 1 Genmachi (Talos OS)             | 3-node Proxmox cluster    |
+| **Network**        | 10.11.x.x (HOMELAB VLAN)          | 10.12.x.x (STAGING VLAN)  |
+| **Purpose**        | Production workloads              | Testing and validation    |
+| **Storage**        | Rook/Ceph (NVMe) + NFS (Synology) | Proxmox storage           |
+| **Apps**           | ~78 HelmReleases                  | Subset for testing        |
+| **Secrets**        | 1Password (production vault)      | 1Password (staging vault) |
+
+---
+
+## Operational Limits
+
+| Resource               | Behavior                                       |
+| ---------------------- | ---------------------------------------------- |
+| Flux reconciliation    | Every 1 hour or on Git push                    |
+| HelmRelease retry      | Retries with exponential backoff               |
+| ExternalSecret refresh | Every 12 hours                                 |
+| Image pull             | Cached by Spegel (distributed registry mirror) |
+
+---
+
+## Storage Patterns
+
+### Capsule: RookCephFast
+
+**Invariant**
+Rook/Ceph provides fast replicated storage from NVMe drives across worker nodes.
+
+**Example**
+
+```yaml
+persistence:
+  data:
+    enabled: true
+    storageClass: rook-ceph-block
+    size: 10Gi
+```
+
+**Depth**
+
+- Use case: Databases, stateful apps requiring fast I/O
+- Replication: 3x across worker nodes
+- Performance: NVMe-backed
+- Trade-off: Limited capacity vs speed and redundancy
+- NotThis: Not for large media files (use NFS instead)
+- SeeAlso: `NFSStorage`
+
+---
+
+### Capsule: NFSStorage
+
+**Invariant**
+NFS provides large slow storage from Synology NAS for media and bulk data.
+
+**Example**
+
+```yaml
+persistence:
+  media:
+    enabled: true
+    type: nfs
+    server: synology.internal
+    path: /volume1/media
+```
+
+**Depth**
+
+- Use case: Media files, downloads, backups
+- Capacity: Multi-TB available
+- Performance: Slower than Ceph but massive capacity
+- Trade-off: Capacity vs speed
+- NotThis: Not for databases or apps requiring fast I/O
+- SeeAlso: `RookCephFast`, `VolSyncBackup`
+
+---
+
+## Bootstrap Process
+
+### Sequence
+
+1. **Talos Installation**
+   - Apply machineconfig.yaml.j2 (rendered) to nodes
+   - Nodes join cluster, bootstrap etcd
+
+2. **Flux Bootstrap** (via Helmfile)
+   - Install CRDs (00-crds.yaml)
+   - Install Flux operators
+   - Install core apps (01-apps.yaml)
+
+3. **Dependency Order**
+   - Cilium (networking)
+   - CoreDNS (cluster DNS)
+   - Spegel (image mirroring)
+   - Cert-Manager (certificates)
+   - Flux (GitOps)
+
+4. **App Deployment**
+   - Flux watches `kubernetes/{main,staging}/apps/`
+   - Reconciles HelmReleases
+   - Creates resources in order
+
+---
+
+## Common Failures
+
+### HelmRelease stuck Reconciling
+
+**Cause**: Missing ExternalSecret, invalid values, or chart error
+**Fix**: Check `flux logs`, ensure ExternalSecrets are Ready, validate values
+**Debug**: `flux get helmreleases -A`, `kubectl describe hr -n <namespace> <name>`
+
+### Pod stuck Pending
+
+**Cause**: ExternalSecret not synced, PVC not bound, or node affinity
+**Fix**: Check `flux get externalsecrets -n <namespace>`, verify PVC exists, check node labels
+**Debug**: `kubectl describe pod -n <namespace> <pod>`
+
+### HTTPRoute not working
+
+**Cause**: Missing gateway, wrong `parentRefs`, or DNS not configured
+**Fix**: Verify gateway exists (`kubectl get gateway -n network`), check external-dns logs
+**Debug**: `kubectl describe httproute -n <namespace> <name>`
+
+### ExternalSecret failing to sync
+
+**Cause**: Missing 1Password entry, wrong path, or onepassword-connect not ready
+**Fix**: Verify entry exists in 1Password, check path format (`op://Vault/Item/Field`)
+**Debug**: `kubectl describe externalsecret -n <namespace> <name>`, check onepassword-connect logs
+
+---
+
+## Automation
+
+### Capsule: RenovateAutomation
+
+**Invariant**
+Renovate automatically updates container images, Helm charts, and GitHub Actions; creates PRs for review.
+
+**Example**
+Renovate detects immich v1.118.0 → v1.118.1, updates image tag and SHA digest, creates PR with changelog.
+
+**Depth**
+
+- Scope: Docker images, Helm charts, GitHub Actions, Taskfile tools
+- Configuration: `.renovaterc.json5` + 11 config files in `.renovate/`
+- Grouping: Separate groups for apps, system, Kubernetes
+- Auto-merge: Patch/minor updates auto-merge if tests pass
+- Trade-off: Automation vs manual control
+- SeeAlso: `ImagePinning`
+
+---
+
+## Evidence
+
+| Claim                          | Source                                                        | Confidence |
+| ------------------------------ | ------------------------------------------------------------- | ---------- |
+| Two independent clusters       | `kubernetes/main/` and `kubernetes/staging/` exist separately | Verified   |
+| Apps use bjw-s/app-template    | `kubernetes/main/apps/*/app/helmrelease.yaml` chart refs      | Verified   |
+| Envoy Gateway routing          | `kubernetes/main/apps/network/envoy-gateway/`                 | Verified   |
+| ExternalSecrets with 1Password | `kubernetes/main/apps/external-secrets/`                      | Verified   |
+| Jinja2 templates               | `.minijinja.toml`, `*.j2` files in `talos/` and `bootstrap/`  | Verified   |
+| Flux reconciles hourly         | `kubernetes/main/apps/*/install.yaml` interval settings       | Verified   |
+| Image digest pinning           | SHA256 digests in helmrelease.yaml files                      | Verified   |
+| Renovate automation            | `.renovaterc.json5`, `.renovate/` configs                     | Verified   |

--- a/docs/ai-context/ARCHITECTURE.md
+++ b/docs/ai-context/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 ---
-description: Dual-cluster GitOps architecture covering Flux reconciliation, template pipeline, routing patterns, and operational constraints
-tags: ["GitOps", "FluxReconciliation", "Jinja2Templates", "EnvoyGateway", "DualCluster", "ExternalSecrets"]
+description: Dual-cluster GitOps architecture — topology, application inventory, GitOps patterns, storage, secrets, and bootstrap
+tags: ["GitOps", "ArgoCD", "DualCluster", "Talos", "k0s", "ExternalSecrets", "Vault"]
 audience: ["LLMs", "Humans"]
 categories: ["Architecture[100%]", "Reference[90%]"]
 ---
@@ -12,341 +12,306 @@ categories: ["Architecture[100%]", "Reference[90%]"]
 ### Capsule: DualClusterIsolation
 
 **Invariant**
-Genmachine and Beelink clusters are independent; no shared code, separate configurations, isolated infrastructure.
+Genmachine and Beelink clusters are independent; no shared code except `gitops/manifests/{app}/common/`.
 
 **Example**
-Genmachine cluster lives in `infra/talos/`; Beelink cluster lives in `infra/k0s/`; changes to one never affect the other.
-//BOUNDARY: No automatic sync between clusters; copying requires explicit manual action.
+Genmachine configuration lives in `infra/talos/genmachine/` and `gitops/manifests/{app}/genmachine/`;
+Beelink lives in `infra/k0s/` and `gitops/manifests/{app}/beelink/`; changes to one never affect the other.
+//BOUNDARY: No automatic sync between clusters; any cross-cluster change requires explicit manual action.
 
 **Depth**
 
-- Distinction: Not environments or branches - completely separate infrastructures
+- Distinction: Not environments or branches — completely separate hardware and OS distributions
+- Beelink: single bare-metal node running k0s v1.32.2 with KubeRouter CNI
+- Genmachine: 3 Proxmox VMs running Talos v1.12.7 / Kubernetes v1.36.0 with Cilium CNI
 - Trade-off: Duplicate configuration for safety vs shared code for consistency
-- NotThis: They don't share namespaces, apps, or ArgoCD state
-- Critical: Always specify which cluster when making changes
-- SeeAlso: `ClusterOrganization`, `GitOpsReconciliation`
+- NotThis: They don't share namespaces, ArgoCD instances, or Vault mounts
+- Critical: Always confirm which cluster before writing any manifest
+- SeeAlso: `GitOpsReconciliation`, `ClusterOrganization`
 
 ---
 
 ### Capsule: GitOpsReconciliation
 
 **Invariant**
-
-- Cluster state converges to match Git; ArgoCD reverts manual changes on next sync.
-- Deployment requires a definition (`Application` or `ApplicationSet` in `gitops/core`) and a manifest (Helm chart or plain YAML in `gitops/manifests`)
+Cluster state converges to match Git; ArgoCD reverts manual changes on next sync (within 3 minutes).
+Deployment requires **both**: a manifest in `gitops/manifests/` **and** an ArgoCD definition in `gitops/core/apps/`.
 
 **Example**
-Push manifests to `gitops/manifest/cilium/genmachine/*`; ArgoCD detects within minutes; cluster deploys. `kubectl edit` gets overwritten on reconciliation.
+Push `gitops/manifests/traefik/genmachine/genmachine-values.yaml`; ArgoCD detects the change, renders the Helm chart,
+and applies the diff. A `kubectl edit` on the same resource gets overwritten on next reconciliation.
 
 **Depth**
 
 - Distinction: GitOps is declarative (desired state in Git); `kubectl` is imperative
 - Trade-off: Consistency and auditability vs immediate manual changes
-- NotThis: `kubectl apply` bypasses GitOps and creates drift
-- Timing: ArgoCD reconciles every 3 minutes
+- NotThis: `kubectl apply` bypasses GitOps and creates drift — do not use for lasting changes
+- Timing: ArgoCD reconciles every 3 minutes; also triggers on Git push via webhook
+- SeeAlso: `ApplicationSetPattern`, `HelmChartConvention`
 
 ---
 
 ### Capsule: ExternalSecretSync
 
 **Invariant**
-ExternalSecrets pull from HC Vault; Kubernetes secrets populate before pods can start.
+ExternalSecrets pull values from HashiCorp Vault; Kubernetes Secrets populate before pods start.
+ClusterSecretStore is named `admin` on both clusters.
 
 **Example**
-Application references `app-secret`; ExternalSecret pulls from `admin/authentik/bootstrap`; pod receives value at runtime.
-//BOUNDARY: Missing Vault entry blocks ExternalSecret sync, blocking pod startup.
+An `ExternalSecret` in `gitops/manifests/wireguard/genmachine/templates/externalsecret.yaml` references
+`admin` store, path `wireguard/oidc/genmachine`; at sync time the operator fetches the value from Vault
+and creates a Kubernetes Secret; the pod mounts it via `secretRef`.
+//BOUNDARY: A missing Vault entry blocks ExternalSecret sync and blocks pod startup.
 
 **Depth**
 
-- Distinction: Vault is source of truth; ExternalSecrets sync values to cluster
-- Trade-off: More indirection, but repo stays public safely and secrets centralized
-- NotThis: Hardcoding secrets in manifests defeats the pattern
-- Store: ClusterSecretStore named `admin`
-- SeeAlso: `OnePasswordIntegration`, `SecretManagement`
+- Auth: Kubernetes service account auth; mount paths are `beelink-k8s` (Beelink) and `genmachine` (Genmachine)
+- Role: `eso`, ServiceAccount: `eso-auth` in `external-secrets` namespace
+- CA: Injected from cert-manager Bundle `fredcorp-ca-chain` (bundle.chain/inject label on namespace)
+- Path convention: `{app}/{secret-type}/{cluster}` — e.g., `wireguard/oidc/beelink`
+- SeeAlso: `VaultPKI`, `SOPSEncryption`
 
 ---
 
-## Routing Patterns
+## Cluster Topology
 
-### Capsule: TraefikRouting
+| Aspect | Beelink (k0s) | Genmachine (Talos) |
+|---|---|---|
+| **Hardware** | Bare-metal BeeLink mini-PC | 3× Proxmox VMs |
+| **OS / Distro** | k0s v1.32.2 | Talos v1.12.7 |
+| **Kubernetes** | v1.32.2 | v1.36.0 |
+| **CNI** | KubeRouter | Cilium |
+| **Load Balancer** | MetalLB | MetalLB |
+| **Nodes** | 1 (192.168.1.190) | 3 (192.168.1.151-153, VIP .150) |
+| **Traefik IP** | 192.168.1.191 | 192.168.1.160 |
+| **DNS domain** | `*.k0s-fullstack.fredcorp.com` | `*.talos-genmachine.fredcorp.com` |
+| **ArgoCD URL** | argocd.k0s-fullstack.fredcorp.com | argocd.talos-genmachine.fredcorp.com |
+| **Vault URL** | vault.k0s-fullstack.fredcorp.com | vault.talos-genmachine.fredcorp.com |
 
-**Invariant**
+---
 
-- External/internal traffic routes via Traefik using `Ingress`.
-- Certificates are created by Cert-manager and PKI is HC Vault
-- Annotations to automate certificate creation from Cert-manager
+## Application Inventory
 
-**Example**
+### Genmachine (Talos) — ApplicationSets
 
-```yaml
-ingress:
-  enabled: true
-  ingressClassName: traefik
-  annotations:
-    cert-manager.io/cluster-issuer: fredcorp-ca
-    cert-manager.io/common-name: homarr.talos-genmachine.fredcorp.com
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/service.scheme: https
-  hosts:
-    - host: homarr.talos-genmachine.fredcorp.com
-      paths:
-        - path: /
-  tls:
-    - secretName: homarr-tls-cert
-      hosts:
-        - homarr.talos-genmachine.fredcorp.com
-```
+| App | Namespace | AppProject | Notes |
+|---|---|---|---|
+| cilium | kube-system | infra-core | CNI; deployed at bootstrap via helmfile |
+| coredns | kube-system | infra-core | Cluster DNS |
+| kubelet-csr-approver | kube-system | infra-core | Auto-approves kubelet CSRs |
+| metrics-server | kube-system | infra-tools | Resource metrics |
+| spegel | spegel | infra-storage | Distributed OCI image mirror |
+| metallb | metallb-system | infra-network | L2 load balancer |
+| traefik | traefik | infra-network | Ingress controller |
+| adguard | adguard | infra-network | DNS / ad-blocking |
+| cert-manager | cert-manager | infra-security | TLS certificates via Vault PKI |
+| external-secrets | external-secrets | infra-security | ESO pulling from Vault |
+| kyverno | kyverno | infra-security | Policy enforcement |
+| vault | vault | infra-security | Secret store (PKI + KV + Transit/SOPS) |
+| authentik | authentik | infra-security | OIDC identity provider |
+| wireguard | wireguard | infra-network | VPN portal (wg-portal) |
+| prometheus | monitoring | monitoring | kube-prometheus-stack |
+| loki | loki | monitoring | Log aggregation |
+| minio | minio | infra-storage | S3-compatible object store |
+| minio-operator | minio-operator | infra-storage | MinIO tenant operator |
+| csi-driver-nfs | csi-driver-nfs | infra-storage | NFS PVC provisioner |
+| proxmox-csi-plugin | proxmox-csi-plugin | infra-storage | Proxmox block storage CSI |
+| volsync | volsync | infra-storage | PVC backup/restore |
+| local-path-provisioner | local-path-storage | infra-storage | HostPath PVC provisioner |
+| homarr | homarr | infra-tools | Dashboard |
+| homepage | homepage | infra-tools | Dashboard alternative |
+| stakater | stakater | infra-tools | Reloader for configmap/secret changes |
+| crossplane | crossplane | infra-tools | Infrastructure CRD provisioner |
+| popeye | popeye | monitoring | Cluster linter |
+| gha-arc-controller | arc-system | infra-tools | GitHub Actions runner controller |
+| system-upgrade | system-upgrade | infra-tools | tuppr — Talos/k8s upgrade controller |
+| fstrim | kube-system | infra-tools | Weekly SSD fstrim CronJob |
+| vrising | vrising | misc | V Rising game server |
 
-**Depth**
+### Beelink (k0s) — Applications
 
-- Distinction: Treafik for `Ingress`, Cilium for CNI
-- SeeAlso: `ExternalDNS`, `ClientTrafficPolicy`
+| App | Namespace | Notes |
+|---|---|---|
+| argocd | argocd | GitOps controller |
+| adguard | adguard | DNS / ad-blocking |
+| authentik | authentik | OIDC identity provider |
+| cert-manager | cert-manager | TLS certificates via Vault PKI |
+| external-secrets | external-secrets | ESO pulling from Vault |
+| homarr | homarr | Dashboard |
+| local-path-provisioner | local-path-storage | HostPath PVC provisioner |
+| metallb | metallb-system | L2 load balancer |
+| stakater | stakater | Reloader |
+| traefik | traefik | Ingress controller |
+| vault | vault | Secret store |
+| wireguard | wireguard | VPN portal |
 
 ---
 
 ## Directory Structure
 
-### Main Cluster
-
-```
-kubernetes/main/
-├── apps/                  # 16 namespaces, 78+ HelmReleases
-│   ├── cert-manager/
-│   ├── dbms/              # CloudNative-PG, Dragonfly, pgAdmin
-│   ├── default/
-│   ├── external-secrets/
-│   ├── flux-system/
-│   ├── home/              # Home Assistant
-│   ├── jobs/
-│   ├── kube-system/       # Cilium, CoreDNS, metrics-server
-│   ├── media/             # Plex, *arr apps, qBittorrent (14 apps)
-│   ├── network/           # Envoy Gateway, external-dns, multus
-│   ├── observability/     # Prometheus, Grafana, Loki
-│   ├── rook-ceph/         # Distributed storage
-│   ├── self-hosted/       # Homepage, WikiJS, PDF tools
-│   ├── system/            # kopia, volsync, descheduler
-│   ├── system-upgrade/
-│   └── actions-runner-system/
-├── bootstrap/             # Helmfile-based bootstrap
-│   ├── helmfile.d/
-│   └── resources.yaml.j2
-├── cluster/               # Flux cluster configuration
-├── components/            # Shared kustomize components
-│   ├── alerts/
-│   ├── app-template/
-│   ├── gatus/
-│   ├── volsync/
-│   └── zeroscaler/
-├── talos/                 # Talos OS configuration
-│   ├── nodes/             # k8s-1 through k8s-6 (.j2 templates)
-│   ├── machineconfig.yaml.j2
-│   └── talosconfig.j2
-└── .justfile             # Cluster-specific tasks
-```
-
-### Staging Cluster
-
-```
-kubernetes/staging/
-├── apps/                  # Same structure as main
-├── bootstrap/
-├── cluster/
-├── components/
-├── talos/
-└── .justfile
-```
-
-**Key Insight**: Each cluster is a complete, independent configuration. No shared code between `main/` and `staging/`.
-
----
-
-## Namespaces (Main Cluster)
-
-| Namespace             | Purpose              | Key Apps                                                        |
-| --------------------- | -------------------- | --------------------------------------------------------------- |
-| actions-runner-system | GitHub Actions       | actions-runner-controller                                       |
-| cert-manager          | TLS certificates     | cert-manager                                                    |
-| dbms                  | Databases            | cloudnative-pg, dragonfly, pgadmin4                             |
-| default               | Test apps            | whoami                                                          |
-| external-secrets      | Secret sync          | external-secrets, onepassword-connect                           |
-| flux-system           | GitOps               | flux controllers, sources, alerts                               |
-| home                  | Home apps            | home-assistant                                                  |
-| jobs                  | Batch jobs           | CronJobs for maintenance                                        |
-| kube-system           | Core Kubernetes      | cilium, coredns, metrics-server, node-feature-discovery         |
-| media                 | Media management     | plex, sonarr, radarr, bazarr, immich, seerr, prowlarr (14 apps) |
-| network               | Networking           | envoy-gateway, external-dns, cloudflare-tunnel, multus          |
-| observability         | Monitoring           | prometheus, grafana, loki, alloy, victoria-logs                 |
-| rook-ceph             | Distributed storage  | rook-ceph-cluster, operators                                    |
-| self-hosted           | Self-hosted services | homepage, wikijs, shlink, pdf-tools, change-detection           |
-| system                | System tools         | kopia, volsync, descheduler, reloader, spegel                   |
-| system-upgrade        | OS updates           | system-upgrade-controller                                       |
-
----
-
-## Cluster Comparison
-
-| Aspect             | Talos Cluster                     | Staging Cluster           |
-| ------------------ | --------------------------------- | ------------------------- |
-| **Infrastructure** | 1 Genmachi (Talos OS)             | 3-node Proxmox cluster    |
-| **Network**        | 10.11.x.x (HOMELAB VLAN)          | 10.12.x.x (STAGING VLAN)  |
-| **Purpose**        | Production workloads              | Testing and validation    |
-| **Storage**        | Rook/Ceph (NVMe) + NFS (Synology) | Proxmox storage           |
-| **Apps**           | ~78 HelmReleases                  | Subset for testing        |
-| **Secrets**        | 1Password (production vault)      | 1Password (staging vault) |
-
----
-
-## Operational Limits
-
-| Resource               | Behavior                                       |
-| ---------------------- | ---------------------------------------------- |
-| Flux reconciliation    | Every 1 hour or on Git push                    |
-| HelmRelease retry      | Retries with exponential backoff               |
-| ExternalSecret refresh | Every 12 hours                                 |
-| Image pull             | Cached by Spegel (distributed registry mirror) |
-
----
-
-## Storage Patterns
-
-### Capsule: RookCephFast
+### Capsule: ClusterOrganization
 
 **Invariant**
-Rook/Ceph provides fast replicated storage from NVMe drives across worker nodes.
+Each cluster has exactly two root directories: `infra/{distro}/` for OS-level config and `gitops/manifests/{app}/{cluster}/` for deployed manifests.
+
+```
+infra/
+├── k0s/fullstack.yaml              # k0sctl cluster spec
+└── talos/genmachine/
+    └── bootstrap/
+        ├── talconfig.yaml          # Talhelper cluster config (generates per-node machineconfigs)
+        ├── clusterconfig/          # Generated; gitignored
+        ├── talsecret.sops.yaml     # SOPS-encrypted Talos secrets
+        └── resources/
+            ├── prepare.sh          # Bootstrap script
+            └── helmfile.yaml       # Bootstrap Helm installs (Cilium, ArgoCD)
+
+gitops/
+├── bootstrap/{beelink,genmachine}/ # ArgoCD installation Helm charts
+├── core/
+│   ├── appProjects/                # 7 AppProject definitions
+│   ├── apps/
+│   │   ├── beelink/                # Plain Application CRDs (one per app)
+│   │   └── genmachine/
+│   │       ├── argo/
+│   │       ├── infra/
+│   │       ├── kube-system/
+│   │       ├── misc/
+│   │       ├── observability/
+│   │       ├── storage/
+│   │       ├── system/
+│   │       └── system-upgrade/
+│   ├── clusters/                   # Cluster destination definitions
+│   └── repos/                      # VCS repo secrets
+└── manifests/{app}/
+    ├── common/common-values.yaml   # Shared Helm values
+    ├── beelink/
+    │   ├── Chart.yaml
+    │   ├── beelink-values.yaml
+    │   └── templates/
+    └── genmachine/
+        ├── Chart.yaml
+        ├── genmachine-values.yaml
+        └── templates/
+```
+
+---
+
+## ApplicationSet Pattern
+
+### Capsule: ApplicationSetPattern
+
+**Invariant**
+Genmachine apps use `ApplicationSet` with a git directory generator. The generator discovers
+`gitops/manifests/{app}/*` directories (excluding `common`, `beelink`, `k0s`) and deploys one
+ArgoCD Application per matching directory (named after the directory).
 
 **Example**
 
 ```yaml
-persistence:
-  data:
-    enabled: true
-    storageClass: rook-ceph-block
-    size: 10Gi
+generators:
+  - git:
+      directories:
+        - path: 'gitops/manifests/traefik/*'
+          exclude: false
+        - path: 'gitops/manifests/traefik/common'
+          exclude: true
+        - path: 'gitops/manifests/traefik/beelink'
+          exclude: true
+        - path: 'gitops/manifests/traefik/k0s'
+          exclude: true
 ```
+
+Generated app name: `traefik-genmachine`. Destination cluster name: `genmachine`.
 
 **Depth**
 
-- Use case: Databases, stateful apps requiring fast I/O
-- Replication: 3x across worker nodes
-- Performance: NVMe-backed
-- Trade-off: Limited capacity vs speed and redundancy
-- NotThis: Not for large media files (use NFS instead)
-- SeeAlso: `NFSStorage`
+- `manifest-generate-paths: .;../common` annotation triggers reconciliation on common changes
+- Value files: `common/common-values.yaml` (shared) + `{cluster}/{cluster}-values.yaml` (override)
+- `ignoreMissingValueFiles: true` prevents failure when a cluster-specific file doesn't exist
+- SeeAlso: `HelmChartConvention`
 
 ---
 
-### Capsule: NFSStorage
+## AppProjects
+
+| Project | Purpose |
+|---|---|
+| `infra-core` | Core Kubernetes infrastructure (CNI, DNS, CSR approver) |
+| `infra-network` | Networking (MetalLB, Traefik, AdGuard, WireGuard) |
+| `infra-security` | Security (cert-manager, ESO, Kyverno, Vault, Authentik) |
+| `infra-storage` | Storage (CSI drivers, MinIO, Volsync, local-path) |
+| `infra-tools` | Tooling (metrics-server, Stakater, ArgoCD, system-upgrade) |
+| `monitoring` | Observability (Prometheus, Loki, Grafana) |
+| `argocd` | ArgoCD itself |
+
+---
+
+## Secrets Architecture
+
+### Capsule: VaultPKI
 
 **Invariant**
-NFS provides large slow storage from Synology NAS for media and bulk data.
+All TLS certificates are issued by cert-manager using Vault as a PKI backend. The cluster issuer is `fredcorp-ca`.
 
 **Example**
-
-```yaml
-persistence:
-  media:
-    enabled: true
-    type: nfs
-    server: synology.internal
-    path: /volume1/media
-```
+An Ingress annotation `cert-manager.io/cluster-issuer: fredcorp-ca` triggers cert-manager to request
+a certificate from Vault's PKI engine. The certificate is stored as a Kubernetes Secret and referenced
+in the Ingress `tls` block.
 
 **Depth**
 
-- Use case: Media files, downloads, backups
-- Capacity: Multi-TB available
-- Performance: Slower than Ceph but massive capacity
-- Trade-off: Capacity vs speed
-- NotThis: Not for databases or apps requiring fast I/O
-- SeeAlso: `RookCephFast`, `VolSyncBackup`
+- CA chain: `fredcorp-ca-chain` cert-manager Bundle injects CA into namespaces with `bundle.chain/inject: enabled` label
+- Wildcard certs: `k0s-fullstack-wildcard`, `genmachine-wildcard` (Traefik default)
+- Per-app pattern: `cert-manager.io/common-name: {app}.{cluster-domain}.fredcorp.com`
+- SeeAlso: `ExternalSecretSync`, `TraefikIngress`
+
+---
+
+### Capsule: SOPSEncryption
+
+**Invariant**
+Files containing secrets committed to Git must end in `.sops.yaml` and be encrypted with Age before commit.
+
+**Example**
+`infra/talos/genmachine/bootstrap/talsecret.sops.yaml` contains encrypted Talos bootstrap secrets.
+The pre-commit hook (`SOPS check-encryption`) blocks commits of unencrypted SOPS files.
+
+**Depth**
+
+- Tool: `age` (asymmetric) — public key in `.sops.yaml` config
+- Encryption: `task sops:encrypt -- <file>`
+- Decryption: `task sops:decrypt -- <file>` (requires private key)
+- Renovate ignores `**/*.sops.*`
+- SeeAlso: `ExternalSecretSync`
 
 ---
 
 ## Bootstrap Process
 
-### Sequence
+### Genmachine (Talos)
 
-1. **Talos Installation**
-   - Apply machineconfig.yaml.j2 (rendered) to nodes
-   - Nodes join cluster, bootstrap etcd
+1. **Provision VMs** on Proxmox with static DHCP MACs → IPs
+2. **Apply Talos machineconfigs** via `task talos:apply` (generated by talhelper from `talconfig.yaml`)
+3. **Bootstrap etcd** on first control-plane node
+4. **Run `resources/helmfile.yaml`** — installs Cilium CNI and ArgoCD via Helm
+5. **Apply `gitops/bootstrap/genmachine/`** — bootstraps ArgoCD app-of-apps
+6. **ArgoCD self-manages** — reconciles all ApplicationSets, deploys all apps
 
-2. **Flux Bootstrap** (via Helmfile)
-   - Install CRDs (00-crds.yaml)
-   - Install Flux operators
-   - Install core apps (01-apps.yaml)
+### Beelink (k0s)
 
-3. **Dependency Order**
-   - Cilium (networking)
-   - CoreDNS (cluster DNS)
-   - Spegel (image mirroring)
-   - Cert-Manager (certificates)
-   - Flux (GitOps)
-
-4. **App Deployment**
-   - Flux watches `kubernetes/{main,staging}/apps/`
-   - Reconciles HelmReleases
-   - Creates resources in order
+1. **Apply k0sctl config** via `task k0s:apply-config` — spins up k0s on the node
+2. **Install ArgoCD** from `gitops/bootstrap/beelink/`
+3. **Apply core Applications** — ArgoCD takes over from there
 
 ---
 
 ## Common Failures
 
-### HelmRelease stuck Reconciling
-
-**Cause**: Missing ExternalSecret, invalid values, or chart error
-**Fix**: Check `flux logs`, ensure ExternalSecrets are Ready, validate values
-**Debug**: `flux get helmreleases -A`, `kubectl describe hr -n <namespace> <name>`
-
-### Pod stuck Pending
-
-**Cause**: ExternalSecret not synced, PVC not bound, or node affinity
-**Fix**: Check `flux get externalsecrets -n <namespace>`, verify PVC exists, check node labels
-**Debug**: `kubectl describe pod -n <namespace> <pod>`
-
-### HTTPRoute not working
-
-**Cause**: Missing gateway, wrong `parentRefs`, or DNS not configured
-**Fix**: Verify gateway exists (`kubectl get gateway -n network`), check external-dns logs
-**Debug**: `kubectl describe httproute -n <namespace> <name>`
-
-### ExternalSecret failing to sync
-
-**Cause**: Missing 1Password entry, wrong path, or onepassword-connect not ready
-**Fix**: Verify entry exists in 1Password, check path format (`op://Vault/Item/Field`)
-**Debug**: `kubectl describe externalsecret -n <namespace> <name>`, check onepassword-connect logs
-
----
-
-## Automation
-
-### Capsule: RenovateAutomation
-
-**Invariant**
-Renovate automatically updates container images, Helm charts, and GitHub Actions; creates PRs for review.
-
-**Example**
-Renovate detects immich v1.118.0 → v1.118.1, updates image tag and SHA digest, creates PR with changelog.
-
-**Depth**
-
-- Scope: Docker images, Helm charts, GitHub Actions, Taskfile tools
-- Configuration: `.renovaterc.json5` + 11 config files in `.renovate/`
-- Grouping: Separate groups for apps, system, Kubernetes
-- Auto-merge: Patch/minor updates auto-merge if tests pass
-- Trade-off: Automation vs manual control
-- SeeAlso: `ImagePinning`
-
----
-
-## Evidence
-
-| Claim                          | Source                                                        | Confidence |
-| ------------------------------ | ------------------------------------------------------------- | ---------- |
-| Two independent clusters       | `kubernetes/main/` and `kubernetes/staging/` exist separately | Verified   |
-| Apps use bjw-s/app-template    | `kubernetes/main/apps/*/app/helmrelease.yaml` chart refs      | Verified   |
-| Envoy Gateway routing          | `kubernetes/main/apps/network/envoy-gateway/`                 | Verified   |
-| ExternalSecrets with 1Password | `kubernetes/main/apps/external-secrets/`                      | Verified   |
-| Jinja2 templates               | `.minijinja.toml`, `*.j2` files in `talos/` and `bootstrap/`  | Verified   |
-| Flux reconciles hourly         | `kubernetes/main/apps/*/install.yaml` interval settings       | Verified   |
-| Image digest pinning           | SHA256 digests in helmrelease.yaml files                      | Verified   |
-| Renovate automation            | `.renovaterc.json5`, `.renovate/` configs                     | Verified   |
+| Symptom | Cause | Fix |
+|---|---|---|
+| Pod stuck `Pending` | ExternalSecret not synced / Vault entry missing | `kubectl describe externalsecret -n <ns> <name>`, check Vault path |
+| ArgoCD app `OutOfSync` loop | ServerSideApply conflict or annotation drift | Check `argocd app diff`, add `RespectIgnoreDifferences` |
+| Certificate not issued | Vault PKI unreachable or wrong issuer name | `kubectl describe certificaterequest -n <ns>` |
+| Pod `CrashLoopBackOff` after secret change | Stakater Reloader not watching annotation | Add `reloader.stakater.com/auto: "true"` annotation |
+| Cilium pod not starting on Talos | `hubble-ui` needs privilege | Check Talos `allowSchedulingOnControlPlanes` and Cilium tolerations |

--- a/docs/ai-context/CONVENTIONS.md
+++ b/docs/ai-context/CONVENTIONS.md
@@ -1,0 +1,308 @@
+---
+description: Coding standards for Helm charts, ApplicationSets, ArgoCD Applications, and manifests
+tags: ["Conventions", "Helm", "ArgoCD", "ApplicationSet"]
+audience: ["LLMs", "Humans"]
+categories: ["Reference[100%]"]
+---
+
+# Conventions
+
+## Helm Chart Structure
+
+Every application follows this layout:
+
+```
+gitops/manifests/{app}/
+├── common/
+│   └── common-values.yaml       # Shared values applied to all clusters
+├── beelink/
+│   ├── Chart.yaml               # Helm wrapper chart (may have upstream dependency)
+│   ├── beelink-values.yaml      # Cluster-specific overrides
+│   └── templates/               # ExternalSecrets, PVCs, custom resources
+└── genmachine/
+    ├── Chart.yaml
+    ├── genmachine-values.yaml
+    └── templates/
+```
+
+### Chart.yaml
+
+```yaml
+---
+apiVersion: v2
+name: {app}
+version: 1.0.0
+dependencies:             # Only present if wrapping an upstream chart
+  - name: {upstream}
+    # renovate: datasource=helm depName={upstream} registryUrl={url}
+    version: 1.2.3
+    repository: https://...
+```
+
+### Value File Naming
+
+- `common/common-values.yaml` — shared configuration (image tags, common labels, feature flags)
+- `{cluster}/{cluster}-values.yaml` — cluster-specific overrides (replicas, domain names, storage class, resource limits)
+
+### Release Name
+
+Helm release name always matches the app directory name:
+```yaml
+helm:
+  releaseName: {app}
+```
+
+---
+
+## ApplicationSet Convention (Genmachine)
+
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: {app}
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: .;../common
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: 'https://github.com/ixxeL-DevOps/fullstack.git'
+        revision: main
+        directories:
+          - path: 'gitops/manifests/{app}/*'
+            exclude: false
+          - path: 'gitops/manifests/{app}/common'
+            exclude: true
+          - path: 'gitops/manifests/{app}/beelink'  # only if beelink dir exists
+            exclude: true
+          - path: 'gitops/manifests/{app}/k0s'       # legacy — exclude if present
+            exclude: true
+  template:
+    metadata:
+      name: '{app}-{{ .path.basenameNormalized }}'
+      annotations:
+        argocd.argoproj.io/manifest-generate-paths: .;../common
+    spec:
+      project: {project}
+      destination:
+        name: '{{ .path.basenameNormalized }}'
+        namespace: {namespace}
+      sources:
+        - path: 'gitops/manifests/{app}/{{ .path.basenameNormalized }}'
+          repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+          targetRevision: main
+          helm:
+            releaseName: {app}
+            valueFiles:
+              - $values/gitops/manifests/{app}/common/common-values.yaml
+              - $values/gitops/manifests/{app}/{{ .path.basenameNormalized }}/{{ .path.basenameNormalized }}-values.yaml
+            ignoreMissingValueFiles: true
+        - repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+          targetRevision: main
+          ref: values
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - Validate=true
+          - PruneLast=true
+          - RespectIgnoreDifferences=true
+          - Replace=false
+          - ApplyOutOfSyncOnly=true
+          - CreateNamespace=true
+          - ServerSideApply=true
+        retry:
+          limit: 6
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+```
+
+**Important**:
+- `manifest-generate-paths: .;../common` appears **twice**: on the ApplicationSet metadata AND the template metadata
+- If the app requires namespace labels (e.g., for CA injection), add `managedNamespaceMetadata.labels`
+- AppProject must be chosen from the existing list — never create a new project without discussion
+
+---
+
+## ArgoCD Application Convention (Beelink)
+
+Beelink uses plain `Application` CRDs (not ApplicationSets):
+
+```yaml
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {app}-beelink
+  namespace: argocd
+spec:
+  project: {project}
+  destination:
+    name: beelink
+    namespace: {namespace}
+  sources:
+    - path: gitops/manifests/{app}/beelink
+      repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+      targetRevision: main
+      helm:
+        releaseName: {app}
+        valueFiles:
+          - $values/gitops/manifests/{app}/common/common-values.yaml
+          - $values/gitops/manifests/{app}/beelink/beelink-values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+      targetRevision: main
+      ref: values
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - Validate=true
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - Replace=false
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+      - ServerSideApply=true
+    retry:
+      limit: 6
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 3m
+```
+
+---
+
+## Ingress Convention
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: fredcorp-ca
+    cert-manager.io/common-name: {app}.{cluster-domain}.fredcorp.com
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/service.scheme: https   # only if backend is HTTPS
+  hosts:
+    - host: {app}.{cluster-domain}.fredcorp.com
+      paths:
+        - path: /
+  tls:
+    - secretName: {app}-tls-cert
+      hosts:
+        - {app}.{cluster-domain}.fredcorp.com
+```
+
+Cluster domains:
+- Beelink: `k0s-fullstack.fredcorp.com`
+- Genmachine: `talos-genmachine.fredcorp.com`
+
+---
+
+## ExternalSecret Convention
+
+```yaml
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {secret-name}
+  namespace: {namespace}
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: {secret-name}
+    creationPolicy: Owner
+  data:
+    - secretKey: {key-in-k8s-secret}
+      remoteRef:
+        key: {app}/{secret-type}/{cluster}
+        property: {vault-key}
+```
+
+Vault path convention: `{app}/{secret-type}/{cluster}` — e.g., `wireguard/oidc/beelink`, `vault/bootstrap/genmachine`.
+
+---
+
+## Renovate Annotations
+
+Always annotate version pins so Renovate can update them:
+
+```yaml
+# Docker image
+image:
+  # renovate: datasource=docker depName=ghcr.io/org/app
+  tag: "v1.2.3"
+
+# Helm chart dependency
+dependencies:
+  - name: cert-manager
+    # renovate: datasource=helm depName=cert-manager registryUrl=https://charts.jetstack.io
+    version: "v1.14.4"
+    repository: https://charts.jetstack.io
+
+# GitHub release
+# renovate: datasource=github-releases depName=org/repo
+version: "0.1.8"
+```
+
+---
+
+## Security Context
+
+For non-privileged workloads, apply:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+```
+
+Only use `privileged: true` when accessing host resources (e.g., fstrim via nsenter). Document why.
+
+---
+
+## Namespace Labels
+
+Namespaces that need the CA chain injected:
+
+```yaml
+managedNamespaceMetadata:
+  labels:
+    bundle.chain/inject: enabled
+```
+
+---
+
+## Naming Summary
+
+| Resource | Pattern |
+|---|---|
+| ApplicationSet name | `{app}` |
+| Application name | `{app}-{cluster}` |
+| Helm release | `{app}` |
+| ArgoCD app (generated) | `{app}-{cluster}` |
+| Vault path | `{app}/{secret-type}/{cluster}` |
+| K8s Secret (from ESO) | `{app}-{secret-type}` |
+| TLS Secret | `{app}-tls-cert` |
+| Ingress hostname | `{app}.{cluster-domain}.fredcorp.com` |

--- a/docs/ai-context/DOMAIN.md
+++ b/docs/ai-context/DOMAIN.md
@@ -1,0 +1,147 @@
+---
+description: Domain glossary, naming rules, hard invariants, and state machines
+tags: ["Domain", "Glossary", "Invariants"]
+audience: ["LLMs", "Humans"]
+categories: ["Reference[100%]"]
+---
+
+# Domain
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| **genmachine** | The Talos-based 3-node Kubernetes cluster running on Proxmox VMs |
+| **beelink** | The k0s-based single-node Kubernetes cluster on bare-metal BeeLink hardware |
+| **talconfig.yaml** | Talhelper input file that generates per-node Talos machineconfigs |
+| **talhelper** | CLI tool that renders `talconfig.yaml` into Talos machineconfig YAML |
+| **ApplicationSet** | ArgoCD resource that generates multiple Applications from a template + generator |
+| **Application** | ArgoCD resource defining a single app's source, destination, and sync policy |
+| **AppProject** | ArgoCD resource scoping allowed sources, destinations, and cluster resources |
+| **common/** | Directory holding Helm values shared across all clusters for an app |
+| **ExternalSecret** | ESO CRD that pulls a secret from Vault and creates a Kubernetes Secret |
+| **ClusterSecretStore** | ESO CRD defining how to connect to Vault; always named `admin` |
+| **SOPS** | Secrets Operations tooling; files ending in `.sops.yaml` are Age-encrypted |
+| **Age** | Asymmetric encryption algorithm used by SOPS for secret files |
+| **Capsule** | A structured documentation unit with Invariant, Example, Depth sections |
+| **Renovate** | Bot that opens PRs to update versions; driven by inline `# renovate:` comments |
+| **tuppr** | Talos/k8s upgrade controller replacing system-upgrade-controller |
+| **wg-portal** | WireGuard Portal — web UI for managing WireGuard VPN users and peers |
+| **Authentik** | Self-hosted OIDC identity provider; source of OIDC tokens for all apps |
+| **fredcorp.com** | Internal domain; all services live under `*.{cluster-domain}.fredcorp.com` |
+
+---
+
+## Hard Invariants
+
+These are facts that must not be violated when making changes:
+
+1. **Two clusters, no shared code** — `common/` values are the only exception
+2. **ArgoCD reverts `kubectl apply`** within 3 minutes; only Git changes persist
+3. **Secrets in Git = SOPS-encrypted** — the pre-commit hook enforces this
+4. **ClusterSecretStore is always named `admin`** — hardcoded in all ExternalSecret templates
+5. **Renovate owns version pins** — do not bump without a `# renovate:` annotation
+6. **Talos nodes are all control-plane** — `allowSchedulingOnControlPlanes: true`; there are no dedicated worker nodes
+7. **Both clusters are independent ArgoCD instances** — no multi-cluster ArgoCD; each cluster manages itself
+8. **Vault PKI is the only certificate authority** — cert-manager issuer is `fredcorp-ca` on both clusters
+
+---
+
+## Naming Rules
+
+### Clusters
+
+| Identifier | Beelink | Genmachine |
+|---|---|---|
+| ArgoCD cluster name | `beelink` | `genmachine` |
+| Directory name | `beelink/` | `genmachine/` |
+| Values file | `beelink-values.yaml` | `genmachine-values.yaml` |
+| DNS subdomain | `k0s-fullstack.fredcorp.com` | `talos-genmachine.fredcorp.com` |
+| Vault k8s auth mount | `beelink-k8s` | `genmachine` |
+
+### Applications
+
+- ArgoCD Application name: `{app}-{cluster}` (e.g., `traefik-genmachine`)
+- Helm release name: always matches app name (e.g., `traefik`)
+- Namespace: matches app name unless app lives in a shared namespace (e.g., `kube-system`)
+- Vault path: `{app}/{secret-type}/{cluster}` (e.g., `wireguard/oidc/beelink`)
+
+---
+
+## State Machines
+
+### ExternalSecret Lifecycle
+
+```
+Created → Pending
+    │
+    ▼
+Vault reachable? ──No──► Error (blocks pod startup)
+    │
+   Yes
+    ▼
+Path exists in Vault? ──No──► Error
+    │
+   Yes
+    ▼
+K8s Secret created → Ready
+    │
+    ▼
+Refreshed every 12h
+```
+
+### ArgoCD Application Lifecycle
+
+```
+ApplicationSet detects new directory
+    │
+    ▼
+Application created (OutOfSync)
+    │
+    ▼
+Helm rendered → diff computed
+    │
+    ▼
+Resources applied (ServerSideApply)
+    │
+    ▼
+Synced (Healthy)
+    │
+    ▼ [any drift]
+OutOfSync → selfHeal → re-sync
+```
+
+### Talos Node Upgrade (via tuppr)
+
+```
+tuppr detects new Talos/k8s version
+    │
+    ▼
+Cordon node
+    │
+    ▼
+Apply new machineconfig / upgrade
+    │
+    ▼
+Node reboots
+    │
+    ▼
+Uncordon node
+    │
+    ▼ [next node]
+Repeat (rolling)
+```
+
+---
+
+## AppProject Assignment Rules
+
+| App type | Project |
+|---|---|
+| CNI, DNS, core k8s | `infra-core` |
+| Ingress, LB, VPN, DNS UI | `infra-network` |
+| Secrets, PKI, OIDC, policy | `infra-security` |
+| CSI drivers, object store, backup | `infra-storage` |
+| Dashboards, runners, operators, fstrim | `infra-tools` |
+| Prometheus, Grafana, Loki, metrics | `monitoring` |
+| ArgoCD bootstrap | `argocd` |

--- a/docs/ai-context/Ethos.md
+++ b/docs/ai-context/Ethos.md
@@ -1,0 +1,66 @@
+---
+description: Hard rules and values that govern all AI assistance in this repository
+tags: ["Philosophy", "Rules"]
+audience: ["LLMs"]
+categories: ["Reference[100%]"]
+---
+
+# Ethos — Hard Rules
+
+These rules are non-negotiable. Apply them before and after every action.
+
+## The Rules
+
+### 1. Cluster Isolation Is Sacred
+
+Beelink and genmachine are not environments of the same cluster. They are independent infrastructures.
+A change for genmachine **never** touches beelink files, and vice versa — unless explicitly asked.
+The only shared files are `gitops/manifests/{app}/common/common-values.yaml`.
+
+### 2. GitOps Is the Only Deployment Path
+
+Never suggest `kubectl apply` as a lasting solution. ArgoCD reverts it on next reconciliation (within 3 minutes).
+All deployments require: a manifest in `gitops/manifests/` **and** a definition in `gitops/core/apps/`.
+
+### 3. Secrets Never Appear in Plain Text
+
+- Vault is the source of truth for all secrets
+- Files containing secrets must end in `.sops.yaml` and be encrypted with Age before commit
+- ExternalSecrets pull values from Vault at runtime — never hardcode them in values files
+- ClusterSecretStore name is `admin` on both clusters
+
+### 4. Renovate Owns Version Bumps
+
+When pinning an image or chart version, always add the appropriate Renovate comment:
+```yaml
+# renovate: datasource=docker depName=ghcr.io/someorg/someimage
+tag: "v1.2.3"
+```
+Manual version bumps without Renovate annotations will immediately fall out of automation.
+
+### 5. Don't Invent Conventions — Match Existing Ones
+
+Before writing a new Helm chart, ApplicationSet, or ExternalSecret, look at an existing one.
+Follow the exact same structure: Chart.yaml format, value file names, template layout, sync policy options.
+
+### 6. Prefer Minimal Diffs
+
+Do not refactor surrounding code when fixing a bug. Do not add abstractions beyond what the task requires.
+A one-line fix should produce a one-line diff. Cleanup belongs in a separate PR.
+
+### 7. Verify Before Declaring Done
+
+A successful `git push` and CI hook pass does not mean ArgoCD synced cleanly.
+For significant changes, check the ArgoCD-generated manifest diff comment on the PR before declaring the task done.
+
+### 8. Ask Which Cluster First
+
+If the request is ambiguous about which cluster, ask before writing any code. Making an assumption
+and writing the wrong cluster's files wastes more time than a clarifying question.
+
+## Values
+
+- **Reproducibility**: The repo should be the single source of truth. If it can't be derived from Git, it shouldn't exist.
+- **Observability**: Prefer solutions that emit metrics (ServiceMonitor, PrometheusRule) and logs.
+- **Least privilege**: SecurityContexts should drop capabilities. Privileged containers are exceptional and documented.
+- **Automation**: Manual operational steps should be codified as Taskfile tasks.

--- a/docs/ai-context/NETWORKING.md
+++ b/docs/ai-context/NETWORKING.md
@@ -1,0 +1,193 @@
+---
+description: Traffic flows, DNS, ingress, certificates, OIDC, and VPN configuration
+tags: ["Networking", "Traefik", "Cilium", "MetalLB", "DNS", "OIDC", "WireGuard", "cert-manager"]
+audience: ["LLMs", "Humans"]
+categories: ["Architecture[90%]", "Reference[85%]"]
+---
+
+# Networking
+
+## Traffic Flow
+
+```
+Internet / LAN client
+        │
+        ▼
+   AdGuard Home (DNS)
+   192.168.1.195
+   *.fredcorp.com → MetalLB VIP
+        │
+        ▼
+   MetalLB (L2 mode)
+   Beelink: 192.168.1.191
+   Genmachine: 192.168.1.160
+        │
+        ▼
+   Traefik Ingress Controller
+   TLS termination (cert-manager / Vault PKI)
+   Entrypoints: web (80→redirect), websecure (443)
+        │
+        ▼
+   Kubernetes Service → Pod
+```
+
+---
+
+## Capsule: TraefikIngress
+
+**Invariant**
+All external traffic routes through Traefik via Kubernetes `Ingress` resources. TLS is terminated at Traefik using cert-manager-issued certificates. Traefik entry point `websecure` (443) is the default; `web` (80) redirects to HTTPS.
+
+**Example**
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: fredcorp-ca
+    cert-manager.io/common-name: vault.talos-genmachine.fredcorp.com
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+  hosts:
+    - host: vault.talos-genmachine.fredcorp.com
+      paths:
+        - path: /
+  tls:
+    - secretName: vault-tls-cert
+      hosts:
+        - vault.talos-genmachine.fredcorp.com
+```
+
+**Depth**
+
+- Genmachine: LoadBalancer IP `192.168.1.160`, 2 replicas, default cert `genmachine-wildcard`
+- Beelink: LoadBalancer IP `192.168.1.191`, 1 replica, default cert `k0s-fullstack-wildcard`
+- KubernetesCRD, KubernetesIngress, and Kubernetes Gateway API providers all enabled
+- Backend HTTPS: add `traefik.ingress.kubernetes.io/service.scheme: https`
+- SeeAlso: `VaultPKI`, `MetalLB`
+
+---
+
+## Capsule: MetalLB
+
+**Invariant**
+MetalLB operates in Layer 2 mode, announcing LoadBalancer Service IPs via ARP.
+
+**Depth**
+
+- Beelink IP range: 192.168.1.191–192.168.1.195
+- Genmachine IP range: starts at 192.168.1.160
+- Traefik always gets the first IP in its range
+- AdGuard Home: 192.168.1.195 (shared DNS server for both clusters)
+
+---
+
+## Capsule: CertManagerVaultPKI
+
+**Invariant**
+cert-manager issues all TLS certificates using Vault as the PKI backend. The `ClusterIssuer` is named `fredcorp-ca`. The CA chain is injected into namespaces via cert-manager `Bundle` (label `bundle.chain/inject: enabled`).
+
+**Depth**
+
+- CA bundle name: `fredcorp-ca-chain`
+- Wildcard certificates for Traefik default TLS: `k0s-fullstack-wildcard`, `genmachine-wildcard`
+- Pattern: one TLS secret per app (`{app}-tls-cert`)
+- SeeAlso: `TraefikIngress`, `ExternalSecretSync`
+
+---
+
+## DNS
+
+### AdGuard Home
+
+Both clusters use AdGuard Home at `192.168.1.195` as the local DNS server.
+
+Wildcard DNS entries resolve all `*.fredcorp.com` subdomains to MetalLB IPs:
+- `*.k0s-fullstack.fredcorp.com` → `192.168.1.191`
+- `*.talos-genmachine.fredcorp.com` → `192.168.1.160`
+
+### CoreDNS
+
+Genmachine runs CoreDNS for in-cluster DNS (`cluster.local`). Beelink uses k0s built-in DNS.
+
+### Naming Pattern
+
+| Cluster | Pattern | Example |
+|---|---|---|
+| Beelink | `{app}.k0s-fullstack.fredcorp.com` | `vault.k0s-fullstack.fredcorp.com` |
+| Genmachine | `{app}.talos-genmachine.fredcorp.com` | `vault.talos-genmachine.fredcorp.com` |
+
+---
+
+## OIDC via Authentik
+
+Authentik is the OIDC identity provider for both clusters. It runs independently on each cluster.
+
+### Provider Configuration Pattern
+
+Each application requiring OIDC needs:
+1. An Authentik `OAuth2Provider` (configured via Blueprint or UI)
+2. An Authentik `Application` linked to the provider
+3. Application-specific OIDC env vars injected via `ExternalSecret` → Kubernetes Secret
+
+### Vault OIDC
+
+```
+Authentik discovery URL: https://authentik.{cluster-domain}/application/o/{slug}/
+Role: reader (default)
+Redirect URIs:
+  - https://vault.{cluster-domain}/oidc/callback
+  - https://vault.{cluster-domain}/ui/vault/auth/oidc/oidc/callback
+```
+
+### WireGuard Portal OIDC
+
+WireGuard Portal uses the `is_admin` claim to grant admin access. This claim is provided via a custom Authentik Scope Mapping:
+
+```python
+return {
+  "is_admin": ak_is_group_member(request.user, name="Wireguard admins")
+}
+```
+
+### Homarr OIDC
+
+```yaml
+env:
+  AUTH_PROVIDERS: credentials,oidc
+  AUTH_OIDC_ISSUER: https://authentik.{cluster-domain}/application/o/fullstack-homarr/
+  AUTH_OIDC_SCOPE_OVERWRITE: openid email profile groups
+  AUTH_OIDC_GROUPS_ATTRIBUTE: groups
+```
+
+---
+
+## VPN (WireGuard)
+
+WireGuard Portal (`wg-portal`) is deployed on both clusters. Users authenticate via Authentik OIDC. Admin status is controlled by the `is_admin` OIDC claim mapped from Authentik group membership.
+
+---
+
+## Capsule: CiliumCNI
+
+**Invariant**
+Genmachine uses Cilium as CNI, installed at bootstrap before any pods can start. Talos is configured with `cni: none` in `talconfig.yaml`; Cilium is installed via `helmfile.yaml` during bootstrap.
+
+**Depth**
+
+- Beelink uses KubeRouter (built into k0s) — no Cilium on Beelink
+- Cilium tolerates `node-role.kubernetes.io/control-plane` — all 3 Talos nodes are control-plane nodes
+- KubeProxy replacement enabled (Cilium handles kube-proxy functionality)
+- SeeAlso: `DualClusterIsolation`
+
+---
+
+## Network CIDRs (Genmachine)
+
+| Range | CIDR |
+|---|---|
+| Pod CIDR | 10.244.0.0/16 |
+| Service CIDR | 10.96.0.0/12 |
+| Node IPs | 192.168.1.151–153 |
+| VIP (control plane) | 192.168.1.150 |
+| Traefik LB | 192.168.1.160 |

--- a/docs/ai-context/PLANNING.md
+++ b/docs/ai-context/PLANNING.md
@@ -1,0 +1,101 @@
+---
+description: Collaborative planning lifecycle — how to scope, design, and validate implementations before writing code
+tags: ["Planning", "Process"]
+audience: ["LLMs"]
+categories: ["Reference[90%]"]
+---
+
+# Planning
+
+## Before Writing Any Code
+
+Answer these questions before touching a single file:
+
+1. **Which cluster?** Beelink, genmachine, or both? If both, are the changes independent?
+2. **What category?** New app deployment, chart update, secret addition, infrastructure change, documentation?
+3. **Does a similar pattern already exist?** Find the nearest existing example and replicate its structure.
+4. **What are the dependencies?** Does this app need Vault secrets? A certificate? A storage class? Are those already present?
+5. **What AppProject?** Use the assignment table in DOMAIN.md.
+
+---
+
+## Planning Phases
+
+### Phase 1 — Clarify
+
+If the request is ambiguous:
+- Ask which cluster before writing manifests
+- Ask if an existing pattern should be followed or if this is intentionally different
+- Ask if secrets need to be created in Vault first
+
+### Phase 2 — Locate
+
+Before writing, locate:
+- The most similar existing app (same type: upstream Helm chart, pure-template chart, etc.)
+- The correct `gitops/core/apps/{cluster}/{category}/` directory
+- Any required pre-existing resources (namespaces, secrets, storage classes)
+
+### Phase 3 — Plan (list files to create/modify)
+
+State explicitly:
+- Files to create (with relative paths)
+- Files to modify (and what changes)
+- Files NOT to touch (and why — e.g., "coredns is excluded from refactor because it's a Talos built-in")
+- Any manual steps required (e.g., "add secret to Vault before deploying")
+
+### Phase 4 — Implement
+
+Follow CONVENTIONS.md for every file written. Use existing files as templates, not this document.
+
+### Phase 5 — Validate
+
+After committing:
+- Pre-commit hooks must pass (yamllint, SOPS check, prettier, commitizen)
+- Commit message must follow conventional commits format: `{type}({scope}): {description}`
+- After PR merge: check the CI manifest diff comment to verify the rendered output matches intent
+
+---
+
+## Commit Message Format
+
+```
+{type}({scope}): {short description}
+
+{optional body}
+
+Closes #{issue}
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `chore`
+Scope: app name or area (e.g., `fstrim`, `traefik`, `talos`, `vault`)
+
+Examples:
+```
+feat(fstrim): add weekly SSD fstrim CronJob for Talos nodes
+fix(traefik): correct wildcard certificate secret name
+refactor(cert-manager): rename values/ to common/
+docs(architecture): add Capsule for CiliumCNI
+```
+
+---
+
+## Scope of Changes
+
+When asked to implement something on "both clusters":
+1. Implement genmachine first (ApplicationSet pattern — more complex)
+2. Implement beelink second (plain Application — simpler, mirrors genmachine)
+3. Commit both in one PR unless the changes are independent
+
+When a change touches `common/common-values.yaml`:
+- This affects all clusters that include that file
+- Verify the change is intentionally shared; if cluster-specific, put it in the cluster values file instead
+
+---
+
+## Red Flags — Stop and Ask
+
+- The request references a cluster by an ambiguous name (e.g., "the cluster", "the server")
+- The request would touch `cilium`, `coredns`, or `kubelet-csr-approver` — these have Talos-specific configs and must be handled carefully
+- The request involves changing Vault's storage backend or auth methods
+- The request asks to commit secrets or credentials
+- The request would affect all apps (e.g., changing a shared ApplicationSet generator pattern)

--- a/docs/ai-context/README.md
+++ b/docs/ai-context/README.md
@@ -1,0 +1,36 @@
+---
+description: Navigation guide for AI context documentation — start here before any task
+tags: ["Navigation", "Overview"]
+audience: ["LLMs"]
+categories: ["Reference[100%]"]
+---
+
+# AI Context — Navigation
+
+This directory provides structured context for AI assistants (Claude and others) working on this repository. Read the documents relevant to your task before planning or executing changes.
+
+## Document Map
+
+| Document | When to Read |
+|---|---|
+| **ARCHITECTURE.md** | Always — cluster topology, app inventory, GitOps patterns |
+| **CONVENTIONS.md** | Before writing or editing any Helm chart, ApplicationSet, or manifest |
+| **NETWORKING.md** | When touching ingress, DNS, certificates, VPN, or OIDC |
+| **DOMAIN.md** | For naming rules, glossary, and hard invariants |
+| **WORKFLOWS.md** | When deploying a new app, updating a chart, or troubleshooting |
+| **TOOLS.md** | Before running CLI commands — Taskfile tasks, talosctl, kubectl |
+| **PLANNING.md** | Before starting a multi-step implementation |
+| **writing-capsules.md** | When writing or updating capsule-format documentation |
+| **mermaid-diagram-guide.md** | When writing Mermaid diagrams for docs/ |
+
+## Critical Facts (Read Before Everything Else)
+
+1. **Two independent clusters**: `genmachine` (Talos, 3-node Proxmox VMs) and `beelink` (k0s, bare-metal single node). No shared code between them except `gitops/manifests/{app}/common/`.
+
+2. **GitOps is the only path**: ArgoCD reconciles every 3 minutes. `kubectl apply` creates drift and gets reverted. All changes go through Git.
+
+3. **Secrets via Vault + ExternalSecrets**: No hardcoded secrets in manifests. Vault is source of truth. SOPS-encrypted files (`*.sops.yaml`) are encrypted with Age before commit.
+
+4. **Renovate manages versions**: Pin versions with a `# renovate:` comment so Renovate picks them up. Never bump versions manually without checking the Renovate datasource annotation.
+
+5. **Cluster-specific directories**: `genmachine/` uses ApplicationSets (one ApplicationSet covers all cluster env dirs). `beelink/` uses plain ArgoCD Applications.

--- a/docs/ai-context/TOOLS.md
+++ b/docs/ai-context/TOOLS.md
@@ -1,0 +1,242 @@
+---
+description: CLI tools available, how to install them, and key commands for cluster management
+tags: ["Tools", "CLI", "Taskfile", "kubectl", "talosctl", "helm"]
+audience: ["LLMs", "Humans"]
+categories: ["Reference[90%]"]
+---
+
+# Tools
+
+## Tool Management
+
+Tools are managed via **mise** (`mise.toml` at repo root). To install all tools:
+
+```bash
+mise install
+```
+
+Python packages (mkdocs, yamllint, etc.) are managed via **uv** (`pyproject.toml`):
+
+```bash
+uv sync
+```
+
+---
+
+## Core Tools
+
+| Tool | Purpose | Install |
+|---|---|---|
+| `kubectl` | Kubernetes CLI | mise |
+| `talosctl` | Talos OS management | mise |
+| `helm` | Kubernetes package manager | mise |
+| `task` | Taskfile runner | mise |
+| `argocd` | ArgoCD CLI | mise |
+| `vault` | HashiCorp Vault CLI | mise |
+| `sops` | Secret file encryption | mise |
+| `age` | Age encryption (used by SOPS) | mise |
+| `talhelper` | Talos machineconfig generator | mise |
+| `helmfile` | Declarative Helm deployment | mise |
+| `kustomize` | Kubernetes manifest overlays | mise |
+| `cilium` | Cilium CLI | mise |
+| `mkdocs` | Documentation site generator | uv (Python) |
+
+---
+
+## Taskfile Reference
+
+The root `Taskfile.yaml` includes sub-taskfiles. Run `task --list` to see all available tasks.
+
+### Talos
+
+```bash
+task talos:apply            # Apply machineconfigs to all nodes
+task talos:bootstrap        # Bootstrap etcd on first node
+task talos:kubeconfig       # Fetch kubeconfig and merge into ~/.kube/config
+task talos:upgrade          # Upgrade Talos OS
+task talos:dashboard        # Open Talos dashboard
+```
+
+### k0s (Beelink)
+
+```bash
+task k0s:kubeconf           # Fetch kubeconfig
+task k0s:apply-config       # Apply k0sctl config
+task k0s:upgrade-cluster    # Upgrade k0s
+```
+
+### Vault
+
+```bash
+task vault:unseal           # Unseal Vault
+task vault:unseal-genmachine  # Unseal Vault on genmachine
+task vault:unseal-beelink     # Unseal Vault on beelink
+```
+
+### ESO (External Secrets)
+
+```bash
+task eso:configure          # Configure ClusterSecretStore on current cluster
+```
+
+### SOPS
+
+```bash
+task sops:encrypt -- <file>   # Encrypt a file with Age
+task sops:decrypt -- <file>   # Decrypt a SOPS file
+```
+
+### Proxmox
+
+```bash
+task proxmox:create-talos   # Create Talos VMs on Proxmox
+```
+
+### Bootstrap
+
+```bash
+task bootstrap:talos        # Full Talos bootstrap sequence
+```
+
+### Helm
+
+```bash
+task helm:update -- <chart-dir>   # Run helm dependency update
+```
+
+### Lint
+
+```bash
+task lint:yaml              # Run yamllint on all YAML files
+```
+
+### MkDocs
+
+```bash
+task mkdocs:serve           # Serve docs locally (http://localhost:8000)
+task mkdocs:build           # Build static docs site
+```
+
+### Restic
+
+```bash
+task restic:backup          # Run a backup
+task restic:restore         # Restore from backup
+```
+
+### Authentik
+
+```bash
+task authentik:apply-blueprint  # Apply an Authentik blueprint
+```
+
+---
+
+## kubectl Quick Reference
+
+```bash
+# Context management
+kubectl config get-contexts
+kubectl config use-context genmachine   # or beelink
+
+# ArgoCD apps
+kubectl get applications -n argocd
+kubectl get applicationsets -n argocd
+
+# ExternalSecrets
+kubectl get externalsecret -A
+kubectl describe externalsecret -n {ns} {name}
+
+# Cert-manager
+kubectl get certificate -A
+kubectl get certificaterequest -A
+
+# Check node status
+kubectl get nodes -o wide
+
+# Check pod status
+kubectl get pods -A | grep -v Running
+```
+
+---
+
+## talosctl Quick Reference
+
+```bash
+# Set talosconfig
+export TALOSCONFIG=infra/talos/genmachine/talosconfig
+
+# Check node health
+talosctl health --nodes 192.168.1.151,192.168.1.152,192.168.1.153
+
+# Get service status
+talosctl services --nodes 192.168.1.151
+
+# View logs
+talosctl logs kubelet --nodes 192.168.1.151
+
+# Apply machineconfig
+talosctl apply-config --nodes 192.168.1.151 --file infra/talos/genmachine/bootstrap/clusterconfig/genmachine-talos-1.yaml
+
+# Dashboard
+talosctl dashboard --nodes 192.168.1.151
+```
+
+---
+
+## argocd Quick Reference
+
+```bash
+# Login
+argocd login argocd.talos-genmachine.fredcorp.com
+
+# List all apps
+argocd app list
+
+# Get app details
+argocd app get {app-name}
+
+# Sync an app
+argocd app sync {app-name}
+
+# Diff (what would change)
+argocd app diff {app-name}
+
+# Hard refresh (force re-render)
+argocd app get {app-name} --hard-refresh
+```
+
+---
+
+## Vault Quick Reference
+
+```bash
+# Login (OIDC)
+vault login -method=oidc -address=https://vault.talos-genmachine.fredcorp.com
+
+# Read a secret
+vault kv get -address=https://vault.talos-genmachine.fredcorp.com {app}/{secret-type}/{cluster}
+
+# Write a secret
+vault kv put -address=https://vault.talos-genmachine.fredcorp.com {app}/{secret-type}/{cluster} key=value
+
+# Check PKI
+vault pki health-check -address=https://vault.talos-genmachine.fredcorp.com fredcorp-pki
+```
+
+---
+
+## Helm Quick Reference
+
+```bash
+# Update dependencies for a chart
+helm dependency update gitops/manifests/{app}/{cluster}/
+
+# Template a chart locally (dry run)
+helm template {release} gitops/manifests/{app}/{cluster}/ \
+  -f gitops/manifests/{app}/common/common-values.yaml \
+  -f gitops/manifests/{app}/{cluster}/{cluster}-values.yaml
+
+# List installed releases
+helm list -A
+```

--- a/docs/ai-context/WORKFLOWS.md
+++ b/docs/ai-context/WORKFLOWS.md
@@ -1,0 +1,219 @@
+---
+description: Step-by-step workflows for deploying apps, updating charts, managing secrets, and troubleshooting
+tags: ["Workflows", "Deployment", "Troubleshooting"]
+audience: ["LLMs", "Humans"]
+categories: ["Reference[95%]"]
+---
+
+# Workflows
+
+## Deploy a New Application
+
+### On Genmachine (ApplicationSet pattern)
+
+1. **Create the Helm chart directory**:
+   ```
+   gitops/manifests/{app}/
+   ├── common/common-values.yaml    ← shared values
+   └── genmachine/
+       ├── Chart.yaml               ← wrapper chart (with upstream dep if needed)
+       ├── genmachine-values.yaml   ← cluster overrides
+       └── templates/               ← ExternalSecrets, PVCs, etc.
+   ```
+
+2. **Create the ApplicationSet** in `gitops/core/apps/genmachine/{category}/{app}.yaml`
+   - Choose the right `{category}` directory: `argo/`, `infra/`, `kube-system/`, `observability/`, `storage/`, `system/`, `system-upgrade/`, `misc/`
+   - Choose the right AppProject from DOMAIN.md
+   - Follow the ApplicationSet template in CONVENTIONS.md
+
+3. **If the app needs secrets**: create an ExternalSecret in `templates/` and add the secret to Vault first
+
+4. **If the app needs a certificate**: add Ingress with cert-manager annotations (see CONVENTIONS.md)
+
+5. **Pin versions with Renovate annotations** (see CONVENTIONS.md)
+
+6. **Commit, push, open PR** — ArgoCD will sync when merged to `main`
+
+### On Beelink (Application pattern)
+
+Same as above but:
+- Use `beelink/` directory instead of `genmachine/`
+- Create a plain `Application` in `gitops/core/apps/beelink/{app}.yaml`
+- Follow the Application template in CONVENTIONS.md
+
+---
+
+## Update a Chart Version
+
+1. Find the version pin in `gitops/manifests/{app}/{cluster}/Chart.yaml` (upstream dependency)
+2. Check the Renovate annotation above the version line
+3. Renovate normally handles this automatically — if doing manually:
+   - Update the version in `Chart.yaml`
+   - Update the image tag in `{cluster}-values.yaml` if needed
+   - Update `Chart.lock` by running `helm dependency update gitops/manifests/{app}/{cluster}/`
+4. Commit — ArgoCD applies the new chart on merge
+
+---
+
+## Add a Secret
+
+1. **Add the secret to Vault** at path `{app}/{secret-type}/{cluster}`:
+   ```bash
+   vault kv put -address=https://vault.k0s-fullstack.fredcorp.com {app}/{secret-type}/{cluster} key=value
+   ```
+
+2. **Create an ExternalSecret** in `gitops/manifests/{app}/{cluster}/templates/externalsecret.yaml`:
+   ```yaml
+   apiVersion: external-secrets.io/v1beta1
+   kind: ExternalSecret
+   metadata:
+     name: {secret-name}
+   spec:
+     secretStoreRef:
+       kind: ClusterSecretStore
+       name: admin
+     target:
+       name: {secret-name}
+     data:
+       - secretKey: {key}
+         remoteRef:
+           key: {app}/{secret-type}/{cluster}
+           property: {vault-field}
+   ```
+
+3. **Reference the secret** in your Helm values or pod spec
+
+---
+
+## Encrypt a Secret File with SOPS
+
+```bash
+task sops:encrypt -- path/to/secret.sops.yaml
+```
+
+The file must be named `*.sops.yaml`. The pre-commit hook blocks unencrypted SOPS files from being committed.
+
+To edit an encrypted file:
+```bash
+task sops:decrypt -- path/to/secret.sops.yaml
+# edit the file
+task sops:encrypt -- path/to/secret.sops.yaml
+```
+
+---
+
+## Bootstrap Genmachine from Scratch
+
+```bash
+# 1. Provision Proxmox VMs (static MAC → IP via DHCP)
+task proxmox:create-talos
+
+# 2. Generate and apply Talos machineconfigs
+task talos:apply
+
+# 3. Bootstrap etcd
+task talos:bootstrap
+
+# 4. Get kubeconfig
+task talos:kubeconfig
+
+# 5. Install Cilium + ArgoCD via helmfile
+cd infra/talos/genmachine/bootstrap/resources
+helmfile apply
+
+# 6. Apply ArgoCD bootstrap (app-of-apps)
+kubectl apply -k gitops/bootstrap/genmachine/
+
+# ArgoCD takes over from here
+```
+
+---
+
+## Upgrade Talos / Kubernetes
+
+Upgrades are handled automatically by **tuppr** (system-upgrade namespace).
+
+To trigger manually:
+```bash
+# Check current versions
+task talos:versions
+
+# Update version in infra/talos/genmachine/bootstrap/talconfig.yaml
+# Then apply machineconfig changes
+task talos:upgrade
+```
+
+---
+
+## Troubleshoot ArgoCD Sync Failure
+
+```bash
+# List all apps and their sync status
+argocd app list
+
+# Get detailed diff for a specific app
+argocd app diff {app}-genmachine
+
+# Force resync
+argocd app sync {app}-genmachine
+
+# Check application logs
+argocd app logs {app}-genmachine
+```
+
+Common causes:
+- ExternalSecret not synced → `kubectl describe externalsecret -n {ns} {name}`
+- Helm render error → check values files for typos, missing keys
+- ServerSideApply conflict → add field to `ignoreDifferences`
+- Namespace missing CA label → add `bundle.chain/inject: enabled` label to namespace
+
+---
+
+## Troubleshoot Pod Not Starting
+
+```bash
+kubectl describe pod -n {namespace} {pod-name}
+kubectl logs -n {namespace} {pod-name} --previous
+
+# Check ExternalSecret
+kubectl get externalsecret -n {namespace}
+kubectl describe externalsecret -n {namespace} {name}
+
+# Check Vault connectivity
+vault status -address=https://vault.{cluster-domain}.fredcorp.com
+```
+
+---
+
+## Run Taskfile Tasks
+
+```bash
+# List available tasks
+task --list
+
+# Common tasks
+task talos:kubeconfig       # Get genmachine kubeconfig
+task k0s:kubeconf           # Get beelink kubeconfig
+task vault:unseal           # Unseal Vault (after restart)
+task eso:configure          # Configure ESO ClusterSecretStore
+task sops:encrypt -- file   # Encrypt a SOPS file
+task sops:decrypt -- file   # Decrypt a SOPS file
+task mkdocs:serve           # Serve documentation locally
+task lint:yaml              # Run yamllint
+```
+
+---
+
+## Update Documentation
+
+```bash
+# Serve locally with live reload
+task mkdocs:serve
+# or: mkdocs serve
+
+# Build static site
+task mkdocs:build
+# or: mkdocs build
+```
+
+Documentation lives in `docs/`. MkDocs config is `mkdocs.yml`. Mermaid diagrams are supported — see `mermaid-diagram-guide.md`.

--- a/docs/ai-context/mermaid-diagram-guide.md
+++ b/docs/ai-context/mermaid-diagram-guide.md
@@ -1,0 +1,154 @@
+---
+description: Rules and patterns for writing Mermaid diagrams in this repository's documentation
+tags: ["Mermaid", "Diagrams", "Documentation"]
+audience: ["LLMs", "Humans"]
+categories: ["Reference[90%]"]
+---
+
+# Mermaid Diagram Guide
+
+## Supported Diagram Types
+
+Mermaid is rendered natively in:
+- **MkDocs** (via `pymdownx.superfences` — configured in `mkdocs.yml`)
+- **GitHub** (native support since 2022 — works in `.md` files, issues, PRs)
+- **README.md and docs/*.md** — use ` ```mermaid ` fences
+
+---
+
+## Diagram Types and When to Use Them
+
+| Type | Directive | Use for |
+|---|---|---|
+| Flowchart | `graph TB` / `graph LR` | Architecture, component relationships, data flows |
+| Sequence | `sequenceDiagram` | Protocol flows, auth sequences, request/response |
+| State | `stateDiagram-v2` | Lifecycle states (pod, ESO, ArgoCD app) |
+| Gitgraph | `gitGraph` | Branch strategies |
+
+---
+
+## Syntax Rules
+
+### Flowchart
+
+```mermaid
+graph TB
+    subgraph Cluster["🖥️ Genmachine (Talos)"]
+        ArgoCD["ArgoCD"]
+        Traefik["Traefik"]
+        Vault["Vault"]
+    end
+
+    Git["GitHub\n(source of truth)"] -->|webhook| ArgoCD
+    ArgoCD --> Traefik
+    ArgoCD --> Vault
+```
+
+- Use `TB` (top-bottom) for architecture diagrams; `LR` (left-right) for flows
+- Use `subgraph` for logical groupings (clusters, namespaces, layers)
+- Node IDs are camelCase; labels can contain spaces and emoji
+- Arrow labels: `-->|label|`
+- Use `["label"]` for rectangles, `(["label"])` for rounded, `{{"label"}}` for diamonds
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant DNS as AdGuard Home
+    participant LB as MetalLB
+    participant Traefik
+    participant App
+
+    User->>DNS: resolve app.talos-genmachine.fredcorp.com
+    DNS-->>User: 192.168.1.160
+    User->>LB: HTTPS :443
+    LB->>Traefik: forward
+    Traefik->>App: proxy (TLS terminated)
+    App-->>User: response
+```
+
+- Use `actor` for external users
+- `->>` for solid arrows (requests), `-->>` for dashed (responses)
+- Add `participant X as "Label"` to alias long names
+
+---
+
+## Style Guidelines
+
+1. **Keep diagrams focused** — one diagram per concept; don't try to show everything
+2. **Use real names** — `vault.talos-genmachine.fredcorp.com` not `my-service`
+3. **Subgraphs for clusters** — always wrap cluster components in a labeled subgraph
+4. **Minimal labels** — arrow labels should be verbs or protocols, not sentences
+5. **Prefer TB for architecture** — left-to-right is better for request flows
+6. **Emoji in subgraph labels** — `🖥️`, `☁️`, `🔐` help distinguish cluster types visually
+
+---
+
+## MkDocs Integration
+
+Mermaid blocks in MkDocs Material use this fenced syntax:
+
+````markdown
+```mermaid
+graph TB
+    A --> B
+```
+````
+
+The `pymdownx.superfences` configuration in `mkdocs.yml` handles rendering:
+
+```yaml
+- pymdownx.superfences:
+    custom_fences:
+      - name: mermaid
+        class: mermaid
+        format: !!python/name:pymdownx.superfences.fence_code_format
+```
+
+No extra JavaScript is needed when using MkDocs Material.
+
+---
+
+## Common Patterns in This Repo
+
+### Traffic Flow (standard)
+
+```mermaid
+graph LR
+    Client -->|DNS| AdGuard
+    AdGuard -->|192.168.1.160| MetalLB
+    MetalLB --> Traefik
+    Traefik -->|TLS terminated| App
+```
+
+### Dual Cluster Overview
+
+```mermaid
+graph TB
+    subgraph BK["🖥️ Beelink — k0s"]
+        B_Traefik["Traefik"] --> B_Vault["Vault"]
+        B_Traefik --> B_Auth["Authentik"]
+    end
+    subgraph GM["🖥️ Genmachine — Talos"]
+        G_Traefik["Traefik"] --> G_Vault["Vault"]
+        G_Traefik --> G_Auth["Authentik"]
+    end
+    GitHub["GitHub\n(source of truth)"] -->|ArgoCD sync| BK
+    GitHub -->|ArgoCD sync| GM
+```
+
+### Secret Sync Flow
+
+```mermaid
+sequenceDiagram
+    participant ESO as ExternalSecrets Operator
+    participant Vault
+    participant K8s as Kubernetes Secret
+    participant Pod
+
+    ESO->>Vault: fetch secret (k8s auth)
+    Vault-->>ESO: secret value
+    ESO->>K8s: create/update Secret
+    Pod->>K8s: mount Secret
+```

--- a/docs/ai-context/writing-capsules.md
+++ b/docs/ai-context/writing-capsules.md
@@ -1,0 +1,88 @@
+---
+description: Format and rules for writing Capsule documentation units
+tags: ["Documentation", "Capsule", "Format"]
+audience: ["LLMs"]
+categories: ["Reference[100%]"]
+---
+
+# Writing Capsules
+
+## What Is a Capsule?
+
+A Capsule is a self-contained documentation unit for a system behavior, architectural invariant, or integration pattern. Capsules are the primary documentation format in `ARCHITECTURE.md` and similar files.
+
+A Capsule answers: **What is always true here, and why does it matter?**
+
+---
+
+## Capsule Format
+
+```markdown
+### Capsule: {PascalCaseName}
+
+**Invariant**
+One or two sentences stating what is always true. Be specific and falsifiable.
+//BOUNDARY: (optional) The edge condition where this invariant can break.
+
+**Example**
+A concrete instance of the invariant in action. Use real code or real hostnames.
+
+**Depth**
+
+- Distinction: What makes this different from a naive assumption
+- Trade-off: What you give up to maintain this invariant
+- NotThis: A common mistake or misconception about this pattern
+- Critical: (optional) A fact that would cause outages if ignored
+- SeeAlso: Related Capsule names (comma-separated)
+```
+
+---
+
+## Rules
+
+1. **Name is PascalCase** and descriptive: `ExternalSecretSync`, `TraefikIngress`, `DualClusterIsolation`
+2. **Invariant is falsifiable** — a reader should be able to test whether it holds
+3. **Example is concrete** — use actual paths, hostnames, resource names from this repo
+4. **Depth is a list** — not prose. Each bullet is one terse thought.
+5. **SeeAlso links Capsules by name** — not by file path; Capsules are looked up by name
+6. **No fluff** — if a Capsule needs more than ~15 lines, split it or move detail to prose
+
+---
+
+## When to Write a Capsule
+
+Write a Capsule when:
+- You need to explain something that would surprise an experienced Kubernetes user
+- You are documenting a cross-cutting concern that affects multiple files
+- You are establishing an invariant that must not be broken
+
+Do **not** write a Capsule for:
+- Simple YAML configuration — a code block with comments is enough
+- Something that is obvious from the Kubernetes docs
+- A one-off procedure — use a numbered list in WORKFLOWS.md instead
+
+---
+
+## Example
+
+```markdown
+### Capsule: ExternalSecretSync
+
+**Invariant**
+ExternalSecrets pull values from HashiCorp Vault; Kubernetes Secrets populate before pods start.
+ClusterSecretStore is named `admin` on both clusters.
+//BOUNDARY: A missing Vault entry blocks ExternalSecret sync and blocks pod startup.
+
+**Example**
+`ExternalSecret` in `gitops/manifests/wireguard/genmachine/templates/externalsecret.yaml` references
+store `admin`, path `wireguard/oidc/genmachine`; at sync the operator creates a Kubernetes Secret;
+the pod mounts it via `secretRef`.
+
+**Depth**
+
+- Distinction: Vault is the source of truth; Kubernetes Secrets are ephemeral caches
+- Trade-off: More indirection vs repo stays public with no embedded secrets
+- NotThis: Do not hardcode secrets in values files — even base64-encoded
+- Critical: Vault must be unsealed for ExternalSecrets to sync on cluster restart
+- SeeAlso: `VaultPKI`, `SOPSEncryption`
+```

--- a/docs/ai-context/writing-documentation.md
+++ b/docs/ai-context/writing-documentation.md
@@ -1,0 +1,83 @@
+---
+description: When and how to write or update documentation in this repository
+tags: ["Documentation", "Writing", "MkDocs"]
+audience: ["LLMs"]
+categories: ["Reference[85%]"]
+---
+
+# Writing Documentation
+
+## When to Write Documentation
+
+Write or update documentation when:
+- A new architectural decision is made that future collaborators need to understand
+- A non-obvious operational procedure is established (the "why" would surprise a reader)
+- A component's integration with others is complex enough to warrant a diagram
+- A hard invariant is added or changed
+
+Do **not** write documentation for:
+- Things that are obvious from reading the code
+- Temporary states (in-progress work, current PR status)
+- Things that will be outdated within days
+- Step-by-step walkthroughs of straightforward Helm chart deployments
+
+---
+
+## Documentation Structure
+
+```
+docs/
+├── index.md                    # Repo homepage (MkDocs)
+├── ai-context/                 # AI assistant context files (this directory)
+├── argocd/                     # ArgoCD-specific docs
+├── authentication/             # OIDC, Authentik docs
+├── cluster/                    # Talos, k0s cluster docs
+├── secrets/                    # Vault, SOPS, ESO docs
+└── assets/                     # Images, diagrams
+```
+
+---
+
+## MkDocs Conventions
+
+- All docs use Markdown with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/) extensions
+- Mermaid diagrams are supported via `pymdownx.superfences` — see `mermaid-diagram-guide.md`
+- Admonitions: `> [!NOTE]`, `> [!CAUTION]`, `> [!TIP]` (GitHub-flavored) or `!!! note`, `!!! warning` (MkDocs)
+- Tabbed content: `=== "Tab Name"` via `pymdownx.tabbed`
+- Code blocks with syntax highlighting: ` ```yaml `, ` ```bash `, etc.
+
+---
+
+## Wisdom Triggers
+
+Write a documentation update when you encounter any of these:
+
+| Trigger | Document in |
+|---|---|
+| "Why is this configured this way?" | A Capsule in ARCHITECTURE.md or the relevant doc file |
+| "This broke because of X undocumented behavior" | DOMAIN.md (invariant) or WORKFLOWS.md (troubleshooting) |
+| "You have to do Y before Z or it fails" | WORKFLOWS.md |
+| "This only applies to cluster X not Y" | ARCHITECTURE.md or CONVENTIONS.md with explicit callout |
+| "The naming here is confusing" | DOMAIN.md (glossary) |
+| A new OIDC integration | docs/authentication/oidc.md |
+| A new certificate pattern | docs/secrets/ or NETWORKING.md |
+
+---
+
+## Capsule Format
+
+For architectural decisions and system behaviors, use the Capsule format (see `writing-capsules.md`).
+
+For operational procedures, use numbered lists with code blocks.
+
+For reference tables, use Markdown tables with concise entries.
+
+---
+
+## Style Rules
+
+1. **One idea per section** — don't mix "how it works" with "how to configure it" in the same block
+2. **Show, don't tell** — include real YAML examples rather than describing the fields abstractly
+3. **No filler** — don't start sections with "This section describes..." or "In this document you will find..."
+4. **Active voice** — "ArgoCD syncs every 3 minutes" not "The sync interval is configured to be 3 minutes"
+5. **Concrete > abstract** — use real hostnames and paths from this repo, not generic placeholders


### PR DESCRIPTION
## Summary

Implements the [szinn/k8s-homelab](https://github.com/szinn/k8s-homelab) AI context documentation pattern, fully adapted to this repo's infrastructure (ArgoCD not Flux, Vault not 1Password, Talos+k0s not staging clusters, etc.).

- **ARCHITECTURE.md** — rewritten from scratch with accurate Capsules for this repo (DualClusterIsolation, GitOpsReconciliation, ExternalSecretSync, ApplicationSetPattern, VaultPKI, SOPSEncryption, ClusterOrganization). The previous version described szinn's infra (Flux, Envoy Gateway, Synology NAS, 1Password) — now describes ours.
- **CONVENTIONS.md** — complete Helm chart structure, ApplicationSet template, Application template, Ingress pattern, ExternalSecret pattern, Renovate annotation format, security context defaults
- **NETWORKING.md** — Traefik, MetalLB, CiliumCNI, cert-manager/Vault PKI, AdGuard DNS, OIDC flows (Vault, WireGuard, Homarr), network CIDRs
- **DOMAIN.md** — glossary of all project-specific terms, hard invariants (8 rules), naming tables, state machines (ESO lifecycle, ArgoCD app lifecycle, tuppr upgrade flow), AppProject assignment rules
- **WORKFLOWS.md** — deploy new app (both clusters), update chart, add secret, SOPS encrypt/decrypt, bootstrap from scratch, Talos upgrade, troubleshoot ArgoCD/pods
- **TOOLS.md** — mise/uv setup, Taskfile task reference, kubectl/talosctl/argocd/vault/helm quick reference
- **PLANNING.md** — 5-phase planning lifecycle, commit message format, red flags to stop and ask
- **writing-capsules.md** / **writing-documentation.md** / **mermaid-diagram-guide.md** — format guides

## Test plan

- [ ] Load `.claude/CLAUDE.md` in a new Claude Code session — verify it can navigate to relevant context files
- [ ] Open a doc with `task mkdocs:serve` and verify all new pages render correctly
- [ ] Verify Mermaid diagrams render on GitHub by browsing `docs/ai-context/ARCHITECTURE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)