### PR TITLE
feat(renovate-operator): deploy self-hosted Renovate via mogenius/renovate-operator

### DIFF
--- a/gitops/core/apps/genmachine/system/renovate-operator.yaml
+++ b/gitops/core/apps/genmachine/system/renovate-operator.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: renovate-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/manifest-generate-paths: .;../common
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: 'https://github.com/ixxeL-DevOps/fullstack.git'
+        revision: main
+        directories:
+          - path: 'gitops/manifests/renovate-operator/*'
+            exclude: false
+          - path: 'gitops/manifests/renovate-operator/common'
+            exclude: true
+  template:
+    metadata:
+      name: 'renovate-operator-{{ .path.basenameNormalized }}'
+      annotations:
+        argocd.argoproj.io/manifest-generate-paths: .;../common
+    spec:
+      project: infra-tools
+      destination:
+        name: '{{ .path.basenameNormalized }}'
+        namespace: renovate-operator
+      sources:
+        - path: 'gitops/manifests/renovate-operator/{{ .path.basenameNormalized }}'
+          repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+          targetRevision: main
+          helm:
+            releaseName: renovate-operator
+            valueFiles:
+              - $values/gitops/manifests/renovate-operator/common/common-values.yaml
+              - $values/gitops/manifests/renovate-operator/{{ .path.basenameNormalized }}/{{ .path.basenameNormalized }}-values.yaml
+            ignoreMissingValueFiles: true
+        - repoURL: https://github.com/ixxeL-DevOps/fullstack.git
+          targetRevision: main
+          ref: values
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - Validate=true
+          - PruneLast=true
+          - RespectIgnoreDifferences=true
+          - Replace=false
+          - ApplyOutOfSyncOnly=true
+          - CreateNamespace=true
+          - ServerSideApply=true
+        retry:
+          limit: 6
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+        managedNamespaceMetadata:
+          labels:
+            bundle.chain/inject: enabled

--- a/gitops/manifests/renovate-operator/common/common-values.yaml
+++ b/gitops/manifests/renovate-operator/common/common-values.yaml
@@ -1,0 +1,30 @@
+---
+renovate-operator:
+  replicaCount: 1
+
+  image:
+    registry: ghcr.io
+    repository: mogenius/renovate-operator
+    pullPolicy: IfNotPresent
+
+  config:
+    defaultJobBackoffLimit: 1
+    defaultJobActiveDeadlineSeconds: 3600
+    deleteSuccessfulJobs: false
+    jobTTLSecondsAfterFinished: 86400
+
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+
+  logging:
+    level: info
+    format: json
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi

--- a/gitops/manifests/renovate-operator/genmachine/Chart.yaml
+++ b/gitops/manifests/renovate-operator/genmachine/Chart.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v2
+name: renovate-operator
+version: 1.0.0
+dependencies:
+  - name: renovate-operator
+    # renovate: datasource=helm depName=renovate-operator registryUrl=https://helm.mogenius.com/public
+    version: 4.5.1
+    repository: https://helm.mogenius.com/public

--- a/gitops/manifests/renovate-operator/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/renovate-operator/genmachine/genmachine-values.yaml
@@ -1,0 +1,9 @@
+---
+renovate-operator:
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoExecute

--- a/gitops/manifests/renovate-operator/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/renovate-operator/genmachine/genmachine-values.yaml
@@ -7,3 +7,16 @@ renovate-operator:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
       effect: NoExecute
+
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    host: renovate-operator.talos-genmachine.fredcorp.com
+    annotations:
+      cert-manager.io/cluster-issuer: fredcorp-ca
+      cert-manager.io/common-name: renovate-operator.talos-genmachine.fredcorp.com
+      traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    tls:
+      - hosts:
+          - renovate-operator.talos-genmachine.fredcorp.com
+        secretName: renovate-operator-tls-cert

--- a/gitops/manifests/renovate-operator/genmachine/templates/externalsecret.yaml
+++ b/gitops/manifests/renovate-operator/genmachine/templates/externalsecret.yaml
@@ -1,23 +1,55 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+# 1. fetch GitHub App Private Key from Secrets Manager
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: renovate-operator-github
-  namespace: renovate-operator
+  name: github-app-pem
 spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: admin
   target:
-    name: renovate-operator-github
-    creationPolicy: Owner
+    name: github-app-pem
   data:
-    - secretKey: RENOVATE_TOKEN
+    - secretKey: private_key_pem
       remoteRef:
-        key: renovate-operator/github/genmachine
-        property: token
-    - secretKey: GITHUB_COM_TOKEN
-      remoteRef:
-        key: renovate-operator/github/genmachine
-        property: token
+        key: github/gh-app/ixxel-devops/pipelines
+        property: PRIVATE_KEY
+---
+# 2. create a GithubAccessToken using GitHub App Credentials
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: GithubAccessToken
+metadata:
+  name: github-auth-token
+spec:
+  appID: "1156216"
+  installID: "61577324"
+  auth:
+    privateKey:
+      secretRef:
+        name: github-app-pem
+        key: private_key_pem
+---
+# 3. create a secret containing the required keys
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-auth-token
+spec:
+  refreshInterval: "45m0s"
+  target:
+    name: renovate-secret
+    template: # template secret to use  GITHUB_COM_TOKEN
+      type: Opaque
+      engineVersion: v2
+      data:
+        GITHUB_COM_TOKEN:  "{{ .token }}"
+        GITHUB_COM_USER: aXh4ZWwyMDk3Cg== # base64 encoded GH username
+        RENOVATE_TOKEN: "{{ .token }}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: GithubAccessToken
+          name: github-auth-token

--- a/gitops/manifests/renovate-operator/genmachine/templates/externalsecret.yaml
+++ b/gitops/manifests/renovate-operator/genmachine/templates/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: renovate-operator-github
+  namespace: renovate-operator
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: renovate-operator-github
+    creationPolicy: Owner
+  data:
+    - secretKey: RENOVATE_TOKEN
+      remoteRef:
+        key: renovate-operator/github/genmachine
+        property: token
+    - secretKey: GITHUB_COM_TOKEN
+      remoteRef:
+        key: renovate-operator/github/genmachine
+        property: token

--- a/gitops/manifests/renovate-operator/genmachine/templates/renovatejob.yaml
+++ b/gitops/manifests/renovate-operator/genmachine/templates/renovatejob.yaml
@@ -13,7 +13,7 @@ spec:
   discoveryFilters:
     - "ixxeL-DevOps/*"
   skipForks: true
-  secretRef: renovate-operator-github
+  secretRef: renovate-secret
   tolerations:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists

--- a/gitops/manifests/renovate-operator/genmachine/templates/renovatejob.yaml
+++ b/gitops/manifests/renovate-operator/genmachine/templates/renovatejob.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: renovate-ixxel-devops
+  namespace: renovate-operator
+spec:
+  # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
+  image: ghcr.io/renovatebot/renovate:40.14.5
+  schedule: "0 */6 * * *"
+  provider:
+    name: github
+  discoveryFilters:
+    - "ixxeL-DevOps/*"
+  skipForks: true
+  secretRef: renovate-operator-github
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoExecute


### PR DESCRIPTION
## Summary

- Deploys [mogenius/renovate-operator](https://github.com/mogenius/renovate-operator) v4.5.1 on the **genmachine** (Talos) cluster
- Creates a `RenovateJob` CR that autodiscovers all `ixxeL-DevOps/*` repos and runs every 6 hours (`0 */6 * * *`)
- Renovate reads the existing `.github/renovate.json` from each discovered repo automatically — no config duplication
- GitHub token pulled from Vault via ExternalSecret (`renovate-operator/github/genmachine`)
- ServiceMonitor enabled for Prometheus integration

## Files

| File | Purpose |
|---|---|
| `gitops/manifests/renovate-operator/genmachine/Chart.yaml` | Helm wrapper chart, renovate-operator 4.5.1 |
| `gitops/manifests/renovate-operator/common/common-values.yaml` | Shared values (metrics, resources, job config) |
| `gitops/manifests/renovate-operator/genmachine/genmachine-values.yaml` | Control-plane tolerations |
| `gitops/manifests/renovate-operator/genmachine/templates/externalsecret.yaml` | GitHub token from Vault |
| `gitops/manifests/renovate-operator/genmachine/templates/renovatejob.yaml` | `RenovateJob` CR — discovery of `ixxeL-DevOps/*` |
| `gitops/core/apps/genmachine/system/renovate-operator.yaml` | ArgoCD ApplicationSet |

## Prerequisites (manual — before merge)

Add the GitHub PAT to Vault on genmachine:

```bash
vault kv put \
  -address=https://vault.talos-genmachine.fredcorp.com \
  renovate-operator/github/genmachine \
  token=<github-pat>
```

The PAT needs: `repo` (read/write), `workflow`, `pull_request` scopes.

> **Note**: If the hosted Mend Renovate bot is currently active, disable it (or remove the GitHub App) to avoid duplicate PRs once self-hosted is running.

## Test plan

- [ ] Vault secret exists at `renovate-operator/github/genmachine`
- [ ] ArgoCD syncs `renovate-operator-genmachine` cleanly
- [ ] ExternalSecret `renovate-operator-github` is `Ready`
- [ ] Operator pod running: `kubectl get pods -n renovate-operator`
- [ ] RenovateJob CR created: `kubectl get renovatejob -n renovate-operator`
- [ ] First run completes: `kubectl get jobs -n renovate-operator`
- [ ] Check Renovate logs: `kubectl logs -n renovate-operator -l job-name=... `

🤖 Generated with [Claude Code](https://claude.com/claude-code)