### PR TITLE
feat(cilium): enable Hubble, BPF pre-allocation, BandwidthManager, IPv4 BIG TCP

### DIFF
--- a/gitops/manifests/cilium/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/cilium/genmachine/genmachine-values.yaml
@@ -11,11 +11,36 @@ cilium:
     pullPolicy: 'IfNotPresent'
 
   hubble:
-    enabled: false
-    ui:
-      enabled: false
+    enabled: true
+    metrics:
+      enabled:
+        - dns:query;ignoreAAAA
+        - drop
+        - tcp
+        - flow
+        - port-distribution
+        - httpV2
+      serviceMonitor:
+        enabled: true
+        labels:
+          release: prometheus
     relay:
-      enabled: false
+      enabled: true
+    ui:
+      enabled: true
+      ingress:
+        enabled: true
+        className: traefik
+        annotations:
+          cert-manager.io/cluster-issuer: fredcorp-ca
+          cert-manager.io/common-name: hubble.talos-genmachine.fredcorp.com
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+        hosts:
+          - hubble.talos-genmachine.fredcorp.com
+        tls:
+          - hosts:
+              - hubble.talos-genmachine.fredcorp.com
+            secretName: hubble-tls-cert
 
   envoy:
     enabled: false

--- a/gitops/manifests/cilium/values/common-values.yaml
+++ b/gitops/manifests/cilium/values/common-values.yaml
@@ -59,3 +59,12 @@ cilium:
   rollOutCiliumPods: true
 
   localRedirectPolicy: true
+
+  bpf:
+    preallocateMaps: true
+
+  bandwidthManager:
+    enabled: true
+    bbr: true
+
+  enableIPv4BIGTCP: true


### PR DESCRIPTION
## Summary

- **Hubble** (observability): active sur genmachine avec relay, UI, ingress Traefik et ServiceMonitor Prometheus
- **BPF preallocateMaps**: pré-allocation des maps BPF pour éviter les pics de latence sous charge
- **BandwidthManager + BBR**: traffic shaping eBPF EDT avec congestion control BBR
- **IPv4 BIG TCP**: segments GRO/GSO jusqu'à 192KB (vs 64KB) pour améliorer le throughput sur kernel 6.18

## Impacts attendus

Ces 4 changements déclenchent un **rolling restart** des pods Cilium agent (via `rollOutCiliumPods: true`). Avec `maxUnavailable: 1` sur 3 nodes, ~30s d'interruption réseau par node, soit ~90s en rolling.

## Test plan

- [ ] Vérifier que les pods Cilium redémarrent en rolling sans stuck
- [ ] Accéder à `https://hubble.talos-genmachine.fredcorp.com` après déploiement
- [ ] Vérifier le ServiceMonitor Hubble dans Prometheus (`/targets`)
- [ ] Vérifier `cilium status` : `BandwidthManager: Enabled`, `IPv4 BIG TCP: Enabled`
- [ ] Vérifier flows dans Hubble UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)