### PR TITLE
feat(cilium): native routing, WireGuard encryption, IPv4 BIG TCP

### DIFF
--- a/gitops/manifests/cilium/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/cilium/genmachine/genmachine-values.yaml
@@ -45,6 +45,17 @@ cilium:
   envoy:
     enabled: false
 
+  routingMode: native
+  autoDirectNodeRoutes: true
+  ipv4NativeRoutingCIDR: "10.244.0.0/16"
+
+  enableIPv4BIGTCP: true
+
+  encryption:
+    enabled: true
+    type: wireguard
+    nodeEncryption: false
+
   # Egress test
   egressGateway:
     enabled: true


### PR DESCRIPTION
## Summary

- **Native routing** : supprime l'encapsulation VXLAN entre les nodes (même L2 `192.168.1.x`) — gain CPU/latence ~5-10%
- **WireGuard** : chiffrement pod-to-pod entre nodes (`nodeEncryption: false` — trafic host exclus)
- **IPv4 BIG TCP** : segments GRO/GSO jusqu'à 192KB, compatible uniquement avec native routing

## ⚠️ Points d'attention avant de merger

### Coupure réseau transitoire (inévitable)
Le passage VXLAN → native routing déclenche un rolling restart des pods Cilium (`rollOutCiliumPods: true`, `maxUnavailable: 1`).  
Pendant la fenêtre de transition (~30-60s par node), un node est en native routing et les deux autres en VXLAN → les pods cross-node sur ce node ne se joignent plus temporairement.  
**Total : ~90s d'impact réseau intermittent. À merger en maintenance.**

### WireGuard + kernel module
Talos 1.12.7 / kernel 6.18.24 inclut WireGuard built-in — pas de module à charger manuellement. Vérification post-deploy : `cilium status | grep Encryption`.

### WireGuard + EgressGateway
EgressGateway est activé sur ce cluster. Les deux fonctionnent ensemble en Cilium 1.19.x mais le trafic egress passe par WireGuard avant de sortir via le gateway node — à surveiller si des règles egress existent.

### BIG TCP
Activé uniquement sur genmachine (override du `false` dans common-values.yaml) car conditionné au native routing.

## Test plan

- [ ] Rolling restart des pods Cilium sans stuck (`kubectl get pods -n kube-system -w`)
- [ ] `cilium status` : `Encryption: Wireguard`, `Routing: Native`, `IPv4 BIG TCP: Enabled`
- [ ] Connectivité cross-node : `cilium connectivity test` ou ping inter-pods
- [ ] Hubble flows : vérifier que les flows apparaissent toujours après le restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)