### PR TITLE
fix(renovate): add kubernetes manager to matchManagers to prevent duplicate PRs

### DIFF
--- a/.renovate/groups.json
+++ b/.renovate/groups.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
       {
-        "matchManagers": ["helmv3", "helm-values", "docker", "regex"],
+        "matchManagers": ["helmv3", "helm-values", "docker", "regex", "kubernetes"],
         "matchFileNames": ["gitops/manifests/**"],
         "groupName": "{{ lookup (split packageFileDir '/') 2 }}-{{ lookup (split packageFileDir '/') 3 }}",
         "addLabels": ["app/{{ lookup (split packageFileDir '/') 2 }}", "env/{{ lookup (split packageFileDir '/') 3 }}"]


### PR DESCRIPTION
## Summary

- Adds `kubernetes` to `matchManagers` in `.renovate/groups.json` grouping rule
- Prevents Renovate from creating duplicate PRs/branches for the same dependency update

## Root cause

Both `helm-values` and `kubernetes` managers share the same `fileMatch` pattern for `gitops/manifests/**` in `.renovate/common.json`. For files like `renovatejob.yaml`, both managers detect the same `image:` field.

The grouping `packageRule` in `groups.json` only listed `["helmv3", "helm-values", "docker", "regex"]` — `kubernetes` was absent. This caused:
- `helm-values` → grouped → branch `renovate/renovate-operator-genmachine` → PR with actual change
- `kubernetes` → **not grouped** → separate branch `renovate/ghcr.io-renovatebot-renovate-43.x` → empty commit (file already updated)

## Fix

```diff
- "matchManagers": ["helmv3", "helm-values", "docker", "regex"],
+ "matchManagers": ["helmv3", "helm-values", "docker", "regex", "kubernetes"],
```

With `kubernetes` in the same group, both detections map to the same branch and Renovate deduplicates the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)