### PR TITLE
feat(vcluster): on-demand vcluster preview environments via ArgoCD PR generator

### DIFF
--- a/gitops/bootstrap/genmachine/templates/externalsecret-github-token.yaml
+++ b/gitops/bootstrap/genmachine/templates/externalsecret-github-token.yaml
@@ -1,22 +1,60 @@
 ---
+# 1. fetch GitHub App private key from Vault
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-app-pem-argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: github-app-pem-argocd
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: private_key_pem
+      remoteRef:
+        key: github/gh-app/ixxel-devops/pipelines
+        property: PRIVATE_KEY
+        conversionStrategy: Default
+        decodingStrategy: Base64
+        metadataPolicy: None
+---
+# 2. generate a short-lived installation token from the GitHub App
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: GithubAccessToken
+metadata:
+  name: github-auth-token-argocd
+spec:
+  appID: "1156216"
+  installID: "61577324"
+  auth:
+    privateKey:
+      secretRef:
+        name: github-app-pem-argocd
+        key: private_key_pem
+---
+# 3. expose the token as a Secret consumable by the ArgoCD PR generator
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: argocd-github-token
 spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: admin
-    kind: ClusterSecretStore
+  refreshInterval: "45m0s"
   target:
     name: argocd-github-token
     creationPolicy: Owner
     deletionPolicy: Retain
-  data:
-    - secretKey: token
-      remoteRef:
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None
-        key: argocd/github-token/genmachine
-        property: TOKEN
+    template:
+      type: Opaque
+      engineVersion: v2
+      data:
+        token: "{{`{{ .token }}`}}"
+  dataFrom:
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: GithubAccessToken
+          name: github-auth-token-argocd

--- a/gitops/bootstrap/genmachine/templates/externalsecret-github-token.yaml
+++ b/gitops/bootstrap/genmachine/templates/externalsecret-github-token.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-github-token
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: admin
+    kind: ClusterSecretStore
+  target:
+    name: argocd-github-token
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+        key: argocd/github-token/genmachine
+        property: TOKEN

--- a/gitops/core/apps/genmachine/infra/vcluster-pr.yaml
+++ b/gitops/core/apps/genmachine/infra/vcluster-pr.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: vcluster-pr-preview
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - pullRequest:
+        github:
+          owner: ixxeL-DevOps
+          repo: fullstack
+          labels:
+            - ci/preview
+          tokenRef:
+            secretName: argocd-github-token
+            key: token
+        requeueAfterSeconds: 60
+  template:
+    metadata:
+      name: 'vcluster-pr-{{ .number }}'
+      annotations:
+        argocd.argoproj.io/manifest-generate-paths: .;../common
+    spec:
+      project: infra-monitoring
+      destination:
+        name: genmachine
+        namespace: 'vcluster-pr-{{ .number }}'
+      sources:
+        - path: gitops/manifests/vcluster/genmachine
+          repoURL: 'https://github.com/ixxeL-DevOps/fullstack.git'
+          targetRevision: main
+          helm:
+            releaseName: 'vcluster-pr-{{ .number }}'
+            valueFiles:
+              - $values/gitops/manifests/vcluster/common/common-values.yaml
+              - $values/gitops/manifests/vcluster/genmachine/genmachine-values.yaml
+            parameters:
+              - name: vcluster.exportKubeConfig.context
+                value: 'vcluster-pr-{{ .number }}'
+              - name: vcluster.exportKubeConfig.server
+                value: 'https://vcluster-pr-{{ .number }}.vcluster-pr-{{ .number }}.svc.cluster.local:443'
+        - repoURL: 'https://github.com/ixxeL-DevOps/fullstack.git'
+          targetRevision: main
+          ref: values
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - ApplyOutOfSyncOnly=true
+          - PruneLast=true
+        retry:
+          limit: 3
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 1m

--- a/gitops/manifests/vcluster/common/common-values.yaml
+++ b/gitops/manifests/vcluster/common/common-values.yaml
@@ -1,0 +1,4 @@
+---
+vcluster:
+  telemetry:
+    enabled: false

--- a/gitops/manifests/vcluster/genmachine/Chart.yaml
+++ b/gitops/manifests/vcluster/genmachine/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+name: vcluster
+version: 1.0.0
+dependencies:
+  - name: vcluster
+    version: 0.34.0
+    repository: https://charts.loft.sh

--- a/gitops/manifests/vcluster/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/vcluster/genmachine/genmachine-values.yaml
@@ -1,0 +1,49 @@
+---
+vcluster:
+  sync:
+    fromHost:
+      ingressClasses:
+        enabled: true
+      storageClasses:
+        enabled: true
+      customResources:
+        clusterissuers.cert-manager.io:
+          enabled: true
+          scope: Cluster
+        clustersecretstores.external-secrets.io:
+          enabled: true
+          scope: Cluster
+    toHost:
+      ingresses:
+        enabled: true
+      customResources:
+        certificates.cert-manager.io:
+          enabled: true
+          scope: Namespaced
+        externalsecrets.external-secrets.io:
+          enabled: true
+          scope: Namespaced
+        secretstores.external-secrets.io:
+          enabled: true
+          scope: Namespaced
+
+  controlPlane:
+    statefulSet:
+      resources:
+        requests:
+          cpu: 200m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 512Mi
+      persistence:
+        volumeClaim:
+          enabled: false
+
+  exportKubeConfig:
+    context: vcluster
+    server: ''
+    insecure: true
+
+  telemetry:
+    enabled: false


### PR DESCRIPTION
## Summary

Adds the infrastructure for spinning up ephemeral vcluster environments on demand when a PR is labeled `ci/preview`. Each vcluster inherits key host cluster capabilities (cert-manager, ESO, Traefik) via vcluster's bidirectional sync.

## Files

| File | Description |
|---|---|
| `gitops/manifests/vcluster/genmachine/Chart.yaml` | Helm wrapper chart for vcluster 0.34.0 from `charts.loft.sh` |
| `gitops/manifests/vcluster/genmachine/genmachine-values.yaml` | Full vcluster config: CRD sync, ingress, no-PVC, resource limits |
| `gitops/manifests/vcluster/common/common-values.yaml` | Common defaults (telemetry disabled) |
| `gitops/core/apps/genmachine/infra/vcluster-pr.yaml` | ApplicationSet with PR generator |
| `gitops/bootstrap/genmachine/templates/externalsecret-github-token.yaml` | ExternalSecret → Vault → `argocd-github-token` Secret |

## Architecture

```
PR labeled ci/preview
    └─ ArgoCD PR generator detects it (requeue every 60s)
        └─ Creates Application: vcluster-pr-<N>
            └─ helm install vcluster-pr-<N>
                namespace: vcluster-pr-<N>
                no PVC (emptyDir) → fully ephemeral

PR closed / label removed
    └─ ArgoCD prunes the Application
        └─ vcluster + namespace deleted automatically
```

## Sync configuration

### Host → Virtual (visible in vcluster)
- `ClusterIssuer` (cert-manager) — same CA as prod
- `ClusterSecretStore` (ESO) — same Vault connection
- `IngressClass` (Traefik) — for ingress routing
- `StorageClass` — host storage classes

### Virtual → Host (host controllers process them)
- `Certificate` → cert-manager issues real certs
- `ExternalSecret` → ESO fetches from Vault
- `SecretStore` — namespace-scoped ESO stores
- `Ingress` → Traefik routes traffic

## Kubeconfig access (for CI runner)

The kubeconfig is stored in Secret `vc-vcluster-pr-<N>` (key: `config`) in namespace `vcluster-pr-<N>`. The server URL is overridden per PR by the ApplicationSet parameter:

```
https://vcluster-pr-<N>.vcluster-pr-<N>.svc.cluster.local:443
```

The ARC runner in `arc-system` can access this directly in-cluster:

```bash
kubectl get secret vc-vcluster-pr-42 -n vcluster-pr-42 \
  -o jsonpath='{.data.config}' | base64 -d > /tmp/vc.kubeconfig
KUBECONFIG=/tmp/vc.kubeconfig helm install my-app ./chart
```

## ⚠️ Before merging: create the Vault secret

The `externalsecret-github-token.yaml` references `argocd/github-token/genmachine` in Vault with property `TOKEN`. Create a GitHub PAT (or App installation token) with `repo:read` scope and store it there:

```
vault kv put argocd/github-token/genmachine TOKEN=<github-pat>
```

The PAT needs: `repo` (read PRs + labels) on `ixxeL-DevOps/fullstack`.

## Usage

```bash
# Trigger a vcluster for PR #123
gh pr edit 123 --add-label ci/preview

# ArgoCD creates vcluster-pr-123 within ~60s
# Remove to teardown
gh pr edit 123 --remove-label ci/preview
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)