### PR TITLE
feat(crossplane/genmachine): add crossview as Helm dependency

### DIFF
--- a/gitops/manifests/crossplane/genmachine/Chart.yaml
+++ b/gitops/manifests/crossplane/genmachine/Chart.yaml
@@ -9,3 +9,7 @@ dependencies:
   - name: komoplane
     version: 0.1.8
     repository: https://helm-charts.komodor.io
+  - name: crossview
+    # renovate: datasource=helm depName=crossview registryUrl=https://crossplane-contrib.github.io/crossview
+    version: 4.3.0
+    repository: https://crossplane-contrib.github.io/crossview

--- a/gitops/manifests/crossplane/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/crossplane/genmachine/genmachine-values.yaml
@@ -28,3 +28,49 @@ komoplane:
       - secretName: komoplane-tls-cert
         hosts:
           - komoplane.talos-genmachine.fredcorp.com
+
+crossview:
+  image:
+    repository: ghcr.io/crossplane-contrib/crossview
+    pullPolicy: IfNotPresent
+    tag: 'v4.3.0'
+
+  ingress:
+    enabled: true
+    className: traefik
+    annotations:
+      cert-manager.io/cluster-issuer: fredcorp-ca
+      cert-manager.io/common-name: crossview.talos-genmachine.fredcorp.com
+      traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    hosts:
+      - host: crossview.talos-genmachine.fredcorp.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: crossview-tls-cert
+        hosts:
+          - crossview.talos-genmachine.fredcorp.com
+
+  database:
+    persistence:
+      storageClass: proxmox-delete
+      size: 5Gi
+
+  secrets:
+    adminUsername:
+      secretKeyRef:
+        name: crossview-credentials
+        key: admin-username
+    adminPassword:
+      secretKeyRef:
+        name: crossview-credentials
+        key: admin-password
+    dbPassword:
+      secretKeyRef:
+        name: crossview-credentials
+        key: db-password
+    sessionSecret:
+      secretKeyRef:
+        name: crossview-credentials
+        key: session-secret

--- a/gitops/manifests/crossplane/genmachine/templates/extsecret-crossview.yaml
+++ b/gitops/manifests/crossplane/genmachine/templates/extsecret-crossview.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: crossview-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: admin
+    kind: ClusterSecretStore
+  target:
+    name: crossview-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: admin-username
+      remoteRef:
+        key: crossview/credentials/genmachine
+        property: admin-username
+    - secretKey: admin-password
+      remoteRef:
+        key: crossview/credentials/genmachine
+        property: admin-password
+    - secretKey: db-password
+      remoteRef:
+        key: crossview/credentials/genmachine
+        property: db-password
+    - secretKey: session-secret
+      remoteRef:
+        key: crossview/credentials/genmachine
+        property: session-secret


### PR DESCRIPTION
## Summary

Adds [crossview](https://github.com/crossplane-contrib/crossview) (Crossplane resource visualization) as a third Helm dependency in the existing crossplane wrapper chart, alongside `crossplane` and `komoplane`.

## Changes

### `Chart.yaml`
```yaml
- name: crossview
  version: 4.3.0   # appVersion v4.3.0
  repository: https://crossplane-contrib.github.io/crossview
```

### `genmachine-values.yaml`
- Traefik ingress at `crossview.talos-genmachine.fredcorp.com` (TLS via cert-manager)
- PostgreSQL persistence on `proxmox-delete` (RWO block, 5Gi)
- All secrets via `secretKeyRef` referencing `crossview-credentials` (no plain-text values)

### `templates/extsecret-crossview.yaml`
ExternalSecret pulling from Vault at `crossview/credentials/genmachine` with keys:
`admin-username`, `admin-password`, `db-password`, `session-secret`

## Namespace

crossview deploys into the `crossplane` namespace (same as crossplane and komoplane). The chart's `crossview.namespace` helper uses `.Release.Namespace` first, so no override needed.

## Secrets mechanism

The crossview chart supports `secretKeyRef` natively in its `secrets:` values — when a value is a map with `secretKeyRef`, the chart's own `secret.yaml` template skips that key and the deployment template references the external secret directly. No plain-text credentials in Git.

## Before syncing

Provision Vault at `crossview/credentials/genmachine`:
```
admin-username   = admin
admin-password   = <choose>
db-password      = <choose>
session-secret   = <openssl rand -base64 32>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)