### PR TITLE
feat(crossplane/genmachine): Authentik OIDC SSO for crossview

### DIFF
--- a/gitops/manifests/authentik/genmachine/blueprints/130-oidc-crossview.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/130-oidc-crossview.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable
+---
+version: 1
+metadata:
+  name: genmachine-crossview
+entries:
+  - id: provider
+    model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: genmachine-crossview
+    attrs:
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      client_type: confidential
+      redirect_uris:
+        - url: https://crossview.talos-genmachine.fredcorp.com/api/auth/oidc/callback
+          matching_mode: strict
+
+      access_code_validity: minutes=1
+      access_token_validity: hours=1
+      refresh_token_validity: hours=2
+
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'openid'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'profile'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'email'"]]
+
+  - id: application
+    model: authentik_core.application
+    state: present
+    identifiers:
+      name: genmachine-crossview
+    attrs:
+      name: genmachine-crossview
+      group: Infrastructure
+      meta_description: crossview
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, genmachine-crossview]]
+      policy_engine_mode: any
+      slug: fullstack-crossview

--- a/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
@@ -21,3 +21,4 @@ configMapGenerator:
       - ./enrollment.yaml
       - ./010-users.yaml
       - ./110-embedded-outpost.yaml
+      - ./130-oidc-crossview.yaml

--- a/gitops/manifests/crossplane/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/crossplane/genmachine/genmachine-values.yaml
@@ -39,6 +39,17 @@ crossview:
     server:
       cors:
         origin: https://crossview.talos-genmachine.fredcorp.com
+    sso:
+      oidc:
+        enabled: true
+        issuer: https://authentik.talos-genmachine.fredcorp.com/application/o/fullstack-crossview/
+        clientId: '' # fill in after creating the Authentik provider
+        callbackURL: https://crossview.talos-genmachine.fredcorp.com/api/auth/oidc/callback
+        scope: openid profile email
+        usernameAttribute: preferred_username
+        emailAttribute: email
+        firstNameAttribute: given_name
+        lastNameAttribute: family_name
 
   secrets:
     adminUsername:
@@ -57,6 +68,10 @@ crossview:
       secretKeyRef:
         name: crossview-credentials
         key: session-secret
+    OIDCClientSecret:
+      secretKeyRef:
+        name: crossview-oidc
+        key: client-secret
 
   ingress:
     enabled: true

--- a/gitops/manifests/crossplane/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/crossplane/genmachine/genmachine-values.yaml
@@ -43,13 +43,20 @@ crossview:
       oidc:
         enabled: true
         issuer: https://authentik.talos-genmachine.fredcorp.com/application/o/fullstack-crossview/
-        clientId: '' # fill in after creating the Authentik provider
         callbackURL: https://crossview.talos-genmachine.fredcorp.com/api/auth/oidc/callback
         scope: openid profile email
         usernameAttribute: preferred_username
         emailAttribute: email
         firstNameAttribute: given_name
         lastNameAttribute: family_name
+
+  app:
+    extraEnv:
+      - name: OIDC_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: crossview-oidc
+            key: client-id
 
   secrets:
     adminUsername:

--- a/gitops/manifests/crossplane/genmachine/templates/externalsecret.yaml
+++ b/gitops/manifests/crossplane/genmachine/templates/externalsecret.yaml
@@ -46,6 +46,10 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   data:
+    - secretKey: client-id
+      remoteRef:
+        key: crossview/oidc/genmachine
+        property: CLIENT_ID
     - secretKey: client-secret
       remoteRef:
         key: crossview/oidc/genmachine

--- a/gitops/manifests/crossplane/genmachine/templates/externalsecret.yaml
+++ b/gitops/manifests/crossplane/genmachine/templates/externalsecret.yaml
@@ -30,3 +30,23 @@ spec:
       remoteRef:
         key: crossview/credentials/genmachine
         property: SESSION_SECRET
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: crossview-oidc
+  namespace: crossplane
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: crossview-oidc
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: client-secret
+      remoteRef:
+        key: crossview/oidc/genmachine
+        property: CLIENT_SECRET


### PR DESCRIPTION
## Summary

Adds Authentik OIDC SSO to crossview on genmachine, with the Authentik provider created declaratively via blueprint.

## Changes

### `authentik/genmachine/blueprints/130-oidc-crossview.yaml` (new)
Blueprint Authentik qui crée le provider OAuth2/OIDC `genmachine-crossview` :
- Confidential client, redirect URI strict vers `/api/auth/oidc/callback`
- Application slug : `fullstack-crossview` (correspond à l'issuer URL configurée)
- Groupe : Infrastructure
- Enregistré dans `kustomization.yaml` → intégré au ConfigMap `authentik-blueprints`

### `crossplane/genmachine/templates/externalsecret.yaml`
ExternalSecret `crossview-oidc` complété avec `client-id` (en plus de `client-secret`), les deux tirés depuis Vault à `crossview/oidc/genmachine`.

### `crossplane/genmachine/genmachine-values.yaml`
- `config.sso.oidc` : OIDC activé, issuer/callbackURL/scope/attributs configurés — sans `clientId` hardcodé
- `app.extraEnv` : injecte `OIDC_CLIENT_ID` depuis le secret `crossview-oidc` — le chart route `clientId` uniquement via ConfigMap, `extraEnv` est positionné en dernier dans la spec du container et override la valeur au runtime
- `secrets.OIDCClientSecret` : toujours via `secretKeyRef` → `crossview-oidc`

## Flux d'auth

```
User → "Sign in with OIDC" → authentik.talos-genmachine.fredcorp.com
     → flow default-provider-authorization-implicit-consent
     → redirect → crossview.talos-genmachine.fredcorp.com/api/auth/oidc/callback
     → user auto-créé dans crossview DB (premier SSO user = admin)
```

## Steps before syncing

**1. Laisser ArgoCD syncer le blueprint Authentik**
Le blueprint crée le provider automatiquement avec un client_id et client_secret générés.

**2. Récupérer les credentials dans Authentik UI**
`authentik.talos-genmachine.fredcorp.com` → Applications → `genmachine-crossview` → copier client_id et client_secret.

**3. Provisionner Vault**
```bash
vault kv put secret/crossview/oidc/genmachine \
  CLIENT_ID=<client_id> \
  CLIENT_SECRET=<client_secret>
```

**4. ArgoCD sync crossplane** → ESO crée `crossview-oidc` secret → crossview démarre avec OIDC activé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)