### PR TITLE
feat(grafana): configure SSO OIDC with Authentik

### DIFF
--- a/gitops/manifests/authentik/genmachine/blueprints/030-groups.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/030-groups.yaml
@@ -52,6 +52,12 @@ entries:
         - !Find [authentik_core.user, [username, ixxel]]
   - model: authentik_core.group
     identifiers:
+      name: Grafana admins
+    attrs:
+      users:
+        - !Find [authentik_core.user, [username, ixxel]]
+  - model: authentik_core.group
+    identifiers:
       name: sa-homarr
     attrs:
       name: sa-homarr

--- a/gitops/manifests/authentik/genmachine/blueprints/120-properties.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/120-properties.yaml
@@ -16,3 +16,14 @@ entries:
         }
       name: wireguard-is-admin
       scope_name: is_admin
+  - model: authentik_providers_oauth2.scopemapping
+    identifiers:
+      name: "OAuth mapping: OpenID 'groups' for Grafana"
+    attrs:
+      description: groups claim for Grafana OIDC role mapping
+      expression: |
+        return {
+          "groups": [g.name for g in request.user.ak_groups.all()]
+        }
+      name: grafana-groups
+      scope_name: groups

--- a/gitops/manifests/authentik/genmachine/blueprints/120-properties.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/120-properties.yaml
@@ -16,14 +16,3 @@ entries:
         }
       name: wireguard-is-admin
       scope_name: is_admin
-  - model: authentik_providers_oauth2.scopemapping
-    identifiers:
-      name: "OAuth mapping: OpenID 'groups' for Grafana"
-    attrs:
-      description: groups claim for Grafana OIDC role mapping
-      expression: |
-        return {
-          "groups": [g.name for g in request.user.ak_groups.all()]
-        }
-      name: grafana-groups
-      scope_name: groups

--- a/gitops/manifests/authentik/genmachine/blueprints/130-oidc-grafana.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/130-oidc-grafana.yaml
@@ -28,7 +28,7 @@ entries:
         - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'openid'"]]
         - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'profile'"]]
         - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'email'"]]
-        - !Find [authentik_core.propertymapping, [name, "OAuth mapping: OpenID 'groups' for Grafana"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'groups'"]]
 
   - id: application
     model: authentik_core.application

--- a/gitops/manifests/authentik/genmachine/blueprints/130-oidc-grafana.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/130-oidc-grafana.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable
+---
+version: 1
+metadata:
+  name: genmachine-grafana
+entries:
+  - id: provider
+    model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: genmachine-grafana
+    attrs:
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      client_type: confidential
+      redirect_uris:
+        - url: https://grafana.talos-genmachine.fredcorp.com/login/generic_oauth
+          matching_mode: strict
+
+      access_code_validity: minutes=1
+      access_token_validity: hours=1
+      refresh_token_validity: hours=2
+
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'openid'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'profile'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'email'"]]
+        - !Find [authentik_core.propertymapping, [name, "OAuth mapping: OpenID 'groups' for Grafana"]]
+
+  - id: application
+    model: authentik_core.application
+    state: present
+    identifiers:
+      name: genmachine-grafana
+    attrs:
+      name: genmachine-grafana
+      group: Monitoring
+      meta_description: Grafana
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, genmachine-grafana]]
+      policy_engine_mode: any
+      slug: genmachine-grafana

--- a/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
@@ -12,6 +12,7 @@ configMapGenerator:
       - ./060-oidc-vault.yaml
       - ./050-oidc-homarr.yaml
       - ./070-oidc-wireguard.yaml
+      - ./130-oidc-grafana.yaml
       - ./100-proxy-traefik.yaml
       - ./090-proxy-adguard.yaml
       - ./030-groups.yaml

--- a/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
@@ -46,6 +46,37 @@ kube-prometheus-stack:
       repository: grafana/grafana
       tag: '12.4.3'
       pullPolicy: IfNotPresent
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+    envFrom:
+      - secretRef:
+          name: grafana-oidc
+    extraVolumes:
+      - name: fredcorp-ca-chain
+        secret:
+          defaultMode: 420
+          secretName: fredcorp-ca-chain
+    extraVolumeMounts:
+      - name: fredcorp-ca-chain
+        mountPath: /etc/ssl/certs/fredcorp-ca-chain.pem
+        subPath: fredcorp-ca-chain.pem
+        readOnly: true
+    grafana.ini:
+      auth:
+        oauth_auto_login: false
+        signout_redirect_url: https://authentik.talos-genmachine.fredcorp.com/application/o/genmachine-grafana/end-session/
+      auth.generic_oauth:
+        enabled: true
+        name: Authentik
+        allow_sign_up: true
+        client_id: ${GF_AUTH_GENERIC_OAUTH_CLIENT_ID}
+        client_secret: ${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}
+        scopes: openid email profile groups
+        auth_url: https://authentik.talos-genmachine.fredcorp.com/application/o/authorize/
+        token_url: https://authentik.talos-genmachine.fredcorp.com/application/o/token/
+        api_url: https://authentik.talos-genmachine.fredcorp.com/application/o/userinfo/
+        role_attribute_path: contains(groups[*], 'Grafana admins') && 'Admin' || 'Viewer'
+        tls_client_ca: /etc/ssl/certs/fredcorp-ca-chain.pem
     ingress:
       enabled: true
       annotations:

--- a/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
@@ -47,7 +47,7 @@ kube-prometheus-stack:
       tag: '12.4.3'
       pullPolicy: IfNotPresent
     podAnnotations:
-      reloader.stakater.com/auto: "true"
+      reloader.stakater.com/auto: 'true'
     envFrom:
       - secretRef:
           name: grafana-oidc
@@ -63,7 +63,7 @@ kube-prometheus-stack:
         readOnly: true
     grafana.ini:
       auth:
-        oauth_auto_login: false
+        oauth_auto_login: true
         signout_redirect_url: https://authentik.talos-genmachine.fredcorp.com/application/o/genmachine-grafana/end-session/
       auth.generic_oauth:
         enabled: true

--- a/gitops/manifests/prometheus/genmachine/templates/externalsecret-grafana-oidc.yaml
+++ b/gitops/manifests/prometheus/genmachine/templates/externalsecret-grafana-oidc.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oidc
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: grafana-oidc
+    creationPolicy: Owner
+  data:
+    - secretKey: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+      remoteRef:
+        key: prometheus/oidc/genmachine
+        property: client_id
+    - secretKey: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+      remoteRef:
+        key: prometheus/oidc/genmachine
+        property: client_secret


### PR DESCRIPTION
## Summary

- **Authentik blueprint** (`130-oidc-grafana.yaml`): crée le provider OIDC et l'application Authentik pour Grafana sur genmachine, avec redirect URI `https://grafana.talos-genmachine.fredcorp.com/login/generic_oauth`
- **Scope mapping** (`120-properties.yaml`): ajoute un mapping `groups` qui retourne les groupes Authentik de l'utilisateur — utilisé par Grafana pour le role mapping
- **Groupe** (`030-groups.yaml`): ajoute `Grafana admins` avec l'user `ixxel`
- **ExternalSecret** (`prometheus/genmachine/templates/externalsecret-grafana-oidc.yaml`): synchronise `client_id` et `client_secret` depuis Vault path `prometheus/oidc/genmachine` vers le secret K8s `grafana-oidc`
- **Grafana values** (`prometheus/genmachine/genmachine-values.yaml`): configure `auth.generic_oauth` avec URLs Authentik, injecte le secret via `envFrom`, monte le CA chain Vault pour les requêtes OIDC, et active Stakater Reloader

## Vault

Avant de merger, créer le secret Vault sur genmachine :

```sh
vault kv put prometheus/oidc/genmachine \
  client_id=<client-id-depuis-authentik> \
  client_secret=<client-secret-depuis-authentik>
```

## Role mapping

Les membres du groupe `Grafana admins` dans Authentik reçoivent le rôle `Admin` dans Grafana. Tous les autres utilisateurs authentifiés reçoivent le rôle `Viewer`.

## Test plan

- [ ] Vérifier que l'ExternalSecret `grafana-oidc` se synchronise (Vault path existant)
- [ ] Accéder à `https://grafana.talos-genmachine.fredcorp.com` → bouton "Sign in with Authentik" présent
- [ ] Login avec l'user `ixxel` → rôle Admin dans Grafana
- [ ] Vérifier le manifest diff ArgoCD sur cette PR avant de merger

🤖 Generated with [Claude Code](https://claude.com/claude-code)