### PR TITLE
fix(grafana): add server.root_url to fix OIDC redirect_uri

### DIFF
--- a/gitops/manifests/authentik/genmachine/blueprints/030-groups.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/030-groups.yaml
@@ -52,6 +52,12 @@ entries:
         - !Find [authentik_core.user, [username, ixxel]]
   - model: authentik_core.group
     identifiers:
+      name: Grafana admins
+    attrs:
+      users:
+        - !Find [authentik_core.user, [username, ixxel]]
+  - model: authentik_core.group
+    identifiers:
       name: sa-homarr
     attrs:
       name: sa-homarr

--- a/gitops/manifests/authentik/genmachine/blueprints/130-oidc-grafana.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/130-oidc-grafana.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable
+---
+version: 1
+metadata:
+  name: genmachine-grafana
+entries:
+  - id: provider
+    model: authentik_providers_oauth2.oauth2provider
+    state: present
+    identifiers:
+      name: genmachine-grafana
+    attrs:
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      client_type: confidential
+      redirect_uris:
+        - url: https://grafana.talos-genmachine.fredcorp.com/login/generic_oauth
+          matching_mode: strict
+
+      access_code_validity: minutes=1
+      access_token_validity: hours=1
+      refresh_token_validity: hours=2
+
+      sub_mode: hashed_user_id
+      property_mappings:
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'openid'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'profile'"]]
+        - !Find [authentik_core.propertymapping, [name, "authentik default OAuth Mapping: OpenID 'email'"]]
+
+  - id: application
+    model: authentik_core.application
+    state: present
+    identifiers:
+      name: genmachine-grafana
+    attrs:
+      name: genmachine-grafana
+      group: Monitoring
+      meta_description: Grafana
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, genmachine-grafana]]
+      policy_engine_mode: any
+      slug: genmachine-grafana

--- a/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
@@ -12,6 +12,7 @@ configMapGenerator:
       - ./060-oidc-vault.yaml
       - ./050-oidc-homarr.yaml
       - ./070-oidc-wireguard.yaml
+      - ./130-oidc-grafana.yaml
       - ./100-proxy-traefik.yaml
       - ./090-proxy-adguard.yaml
       - ./030-groups.yaml

--- a/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
@@ -62,6 +62,8 @@ kube-prometheus-stack:
         subPath: fredcorp-ca-chain.pem
         readOnly: true
     grafana.ini:
+      server:
+        root_url: https://grafana.talos-genmachine.fredcorp.com
       auth:
         oauth_auto_login: true
         signout_redirect_url: https://authentik.talos-genmachine.fredcorp.com/application/o/genmachine-grafana/end-session/

--- a/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
@@ -46,6 +46,37 @@ kube-prometheus-stack:
       repository: grafana/grafana
       tag: '12.4.3'
       pullPolicy: IfNotPresent
+    podAnnotations:
+      reloader.stakater.com/auto: 'true'
+    envFrom:
+      - secretRef:
+          name: grafana-oidc
+    extraVolumes:
+      - name: fredcorp-ca-chain
+        secret:
+          defaultMode: 420
+          secretName: fredcorp-ca-chain
+    extraVolumeMounts:
+      - name: fredcorp-ca-chain
+        mountPath: /etc/ssl/certs/fredcorp-ca-chain.pem
+        subPath: fredcorp-ca-chain.pem
+        readOnly: true
+    grafana.ini:
+      auth:
+        oauth_auto_login: true
+        signout_redirect_url: https://authentik.talos-genmachine.fredcorp.com/application/o/genmachine-grafana/end-session/
+      auth.generic_oauth:
+        enabled: true
+        name: Authentik
+        allow_sign_up: true
+        client_id: ${GF_AUTH_GENERIC_OAUTH_CLIENT_ID}
+        client_secret: ${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}
+        scopes: openid email profile groups
+        auth_url: https://authentik.talos-genmachine.fredcorp.com/application/o/authorize/
+        token_url: https://authentik.talos-genmachine.fredcorp.com/application/o/token/
+        api_url: https://authentik.talos-genmachine.fredcorp.com/application/o/userinfo/
+        role_attribute_path: contains(groups[*], 'Grafana admins') && 'Admin' || 'Viewer'
+        tls_client_ca: /etc/ssl/certs/fredcorp-ca-chain.pem
     ingress:
       enabled: true
       annotations:

--- a/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
@@ -48,9 +48,8 @@ kube-prometheus-stack:
       pullPolicy: IfNotPresent
     podAnnotations:
       reloader.stakater.com/auto: 'true'
-    envFrom:
-      - secretRef:
-          name: grafana-oidc
+    envFromSecrets:
+      - name: grafana-oidc
     extraVolumes:
       - name: fredcorp-ca-chain
         secret:

--- a/gitops/manifests/prometheus/genmachine/templates/externalsecret-grafana-oidc.yaml
+++ b/gitops/manifests/prometheus/genmachine/templates/externalsecret-grafana-oidc.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oidc
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: grafana-oidc
+    creationPolicy: Owner
+  data:
+    - secretKey: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+      remoteRef:
+        key: grafana/oidc/genmachine
+        property: client-id
+    - secretKey: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+      remoteRef:
+        key: grafana/oidc/genmachine
+        property: client-secret


### PR DESCRIPTION
## Problème

Grafana envoyait `redirect_uri=http://grafana.talos-genmachine.fredcorp.com:3000/login/generic_oauth` lors du flux OIDC — l'URL interne du service (port 3000, http) au lieu de l'URL externe. Authentik rejetait la requête car cela ne correspond pas au `redirect_uri` enregistré dans le provider.

## Fix

Ajout de `server.root_url` dans `grafana.ini` :

```yaml
server:
  root_url: https://grafana.talos-genmachine.fredcorp.com
```

Grafana utilise cette valeur pour construire le `redirect_uri` envoyé à Authentik.

## Autre erreur en cours (non liée à ce fix)

`client_id=` vide → le secret Vault `prometheus/oidc/genmachine` doit être peuplé avec les valeurs du provider Authentik :

```sh
vault kv put prometheus/oidc/genmachine \
  client_id=<valeur depuis Authentik Admin > Providers > genmachine-grafana> \
  client_secret=<valeur depuis Authentik Admin > Providers > genmachine-grafana>
```

Une fois le secret Vault créé, l'ExternalSecret `grafana-oidc` se synchronise et le pod redémarre automatiquement (Stakater Reloader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)