### PR TITLE
fix(grafana): replace envFrom with envFromSecrets for OIDC secret injection

### DIFF
--- a/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
@@ -48,9 +48,8 @@ kube-prometheus-stack:
       pullPolicy: IfNotPresent
     podAnnotations:
       reloader.stakater.com/auto: 'true'
-    envFrom:
-      - secretRef:
-          name: grafana-oidc
+    envFromSecrets:
+      - name: grafana-oidc
     extraVolumes:
       - name: fredcorp-ca-chain
         secret:
@@ -138,3 +137,4 @@ prometheus-pushgateway:
     namespace: prometheus
     additionalLabels:
       release: prometheus
+


### PR DESCRIPTION
## Problème

La clé `envFrom` n'existe pas dans le grafana helm chart 12.3.1. Elle était silencieusement ignorée, ce qui empêchait l'injection des env vars `GF_AUTH_GENERIC_OAUTH_CLIENT_ID` et `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` dans le container Grafana.

**Vérification** : diagnostic cluster + inspection du chart téléchargé depuis `https://github.com/grafana-community/helm-charts/releases/download/grafana-12.3.1/grafana-12.3.1.tgz` → `values.yaml` ne contient pas de clé `envFrom`, uniquement `envFromSecret` (string) et `envFromSecrets` (liste).

## Fix

```yaml
# Avant (ignoré silencieusement)
envFrom:
  - secretRef:
      name: grafana-oidc

# Après (clé supportée par grafana chart 12.3.1)
envFromSecrets:
  - name: grafana-oidc
```

## Vérification post-merge

Une fois ArgoCD syncé et le pod redémarré (Stakater Reloader) :

```sh
kubectl exec -n prometheus <grafana-pod> -c grafana -- env | grep GF_AUTH_GENERIC_OAUTH
# Doit retourner les deux variables avec des valeurs non vides
```

Et dans `grafana.ini` du pod, `client_id` et `client_secret` doivent être substitués :

```sh
kubectl exec -n prometheus <grafana-pod> -c grafana -- cat /etc/grafana/grafana.ini | grep client_id
# Doit retourner la valeur réelle, pas ${GF_AUTH_GENERIC_OAUTH_CLIENT_ID}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)