### PR TITLE
fix(grafana): use extraContainerVolumes for CA chain secret mount

### DIFF
--- a/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/prometheus/genmachine/genmachine-values.yaml
@@ -50,7 +50,7 @@ kube-prometheus-stack:
       reloader.stakater.com/auto: 'true'
     envFromSecrets:
       - name: grafana-oidc
-    extraVolumes:
+    extraContainerVolumes:
       - name: fredcorp-ca-chain
         secret:
           defaultMode: 420
@@ -137,4 +137,3 @@ prometheus-pushgateway:
     namespace: prometheus
     additionalLabels:
       release: prometheus
-


### PR DESCRIPTION
## Problème

`extraVolumes` dans le chart grafana 12.3.1 ne supporte pas le type `secret:`. Le template `_pod.tpl` ligne 1719 tombe dans le fallback `emptyDir: {}` pour tout type non reconnu — seuls `existingClaim`, `hostPath`, `csi`, `configMap`, `emptyDir` sont traités explicitement.

Résultat : `/etc/ssl/certs/fredcorp-ca-chain.pem` était un répertoire vide au lieu d'un fichier PEM, causant :

```
Failed to setup TlsClientCa: read /etc/ssl/certs/fredcorp-ca-chain.pem: is a directory
```

**Vérification** : inspecté `_pod.tpl` depuis le chart téléchargé `grafana-12.3.1.tgz` — branche `secret` absente du `if/else if` dans `{{- range .Values.extraVolumes }}`.

## Fix

Remplacement de `extraVolumes` par `extraContainerVolumes` qui utilise `tpl (toYaml .) $root | nindent 2` — rendu YAML brut, compatible avec tous les types de volume dont `secret:`.

```yaml
# Avant
extraVolumes:
  - name: fredcorp-ca-chain
    secret:
      secretName: fredcorp-ca-chain   # → emptyDir: {} (fallback silencieux)

# Après
extraContainerVolumes:
  - name: fredcorp-ca-chain
    secret:
      secretName: fredcorp-ca-chain   # → rendu tel quel
```

## Vérification post-merge

```sh
kubectl exec -n prometheus <grafana-pod> -c grafana -- ls -la /etc/ssl/certs/fredcorp-ca-chain.pem
# Doit être un fichier (-rw-r--r--), pas un répertoire (drwx...)

kubectl exec -n prometheus <grafana-pod> -c grafana -- head -1 /etc/ssl/certs/fredcorp-ca-chain.pem
# Doit retourner : -----BEGIN CERTIFICATE-----
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)