### PR TITLE
feat(homepage): configure ArgoCD widget with dedicated readonly account

### DIFF
--- a/gitops/bootstrap/genmachine/genmachine-values.yaml
+++ b/gitops/bootstrap/genmachine/genmachine-values.yaml
@@ -217,6 +217,7 @@ argo-cd:
       create: true
       accounts.fred: 'apiKey, login'
       accounts.pipeline: 'apiKey'
+      accounts.sa-homepage: 'apiKey'
       # -- Argo CD's externally facing base URL (optional). Required when configuring SSO
       url: 'https://argocd.talos-genmachine.fredcorp.com'
       dex.config: |
@@ -269,6 +270,7 @@ argo-cd:
         p, role:readonly, extensions, invoke, metrics, allow
         p, role:admin, extensions, invoke, metrics, allow
         g, Argocd admins, role:admin
+        g, sa-homepage, role:readonly
 
       # See : https://github.com/argoproj-labs/argocd-extension-metrics#install-ui-extension
     params:

--- a/gitops/manifests/homepage/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/homepage/genmachine/genmachine-values.yaml
@@ -17,6 +17,9 @@ homepage:
     - name: homepage-config
       configMap:
         name: homepage-config
+    - name: homepage-argocd-token
+      secret:
+        secretName: homepage-argocd-token
 
   volumeMounts:
     - mountPath: /app/config/custom.css
@@ -40,6 +43,10 @@ homepage:
     - mountPath: /app/config/widgets.yaml
       name: homepage-config
       subPath: widgets.yaml
+    - mountPath: /app/config/secrets/argocd-token
+      name: homepage-argocd-token
+      readOnly: true
+      subPath: token
 
   ingress:
     enabled: true

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -154,7 +154,7 @@ data:
             widget:
               type: argocd
               url: https://argocd.talos-genmachine.fredcorp.com
-              key: "{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}"
+              key: "{{ "{{" }}HOMEPAGE_FILE_/app/config/secrets/argocd-token{{ "}}" }}"
               fields: ["apps", "outOfSync", "healthy", "degraded"]
         - AdGuard:
             href: https://adguard.talos-genmachine.fredcorp.com

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -154,7 +154,7 @@ data:
             widget:
               type: argocd
               url: https://argocd.talos-genmachine.fredcorp.com
-              token: "{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}"
+              key: "{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}"
               fields: ["apps", "outOfSync", "healthy", "degraded"]
         - AdGuard:
             href: https://adguard.talos-genmachine.fredcorp.com

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -154,6 +154,7 @@ data:
             widget:
               type: argocd
               url: https://argocd.talos-genmachine.fredcorp.com
+              token: "{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}"
               fields: ["apps", "outOfSync", "healthy", "degraded"]
         - AdGuard:
             href: https://adguard.talos-genmachine.fredcorp.com

--- a/gitops/manifests/homepage/genmachine/templates/externalsecret.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/externalsecret.yaml
@@ -12,7 +12,7 @@ spec:
     name: homepage-argocd-token
     creationPolicy: Owner
   data:
-    - secretKey: HOMEPAGE_VAR_ARGOCD_TOKEN
+    - secretKey: token
       remoteRef:
         key: homepage/argocd/genmachine
         property: token

--- a/gitops/manifests/homepage/genmachine/templates/externalsecret.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homepage-argocd-token
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: homepage-argocd-token
+    creationPolicy: Owner
+  data:
+    - secretKey: HOMEPAGE_VAR_ARGOCD_TOKEN
+      remoteRef:
+        key: homepage/argocd/genmachine
+        property: token


### PR DESCRIPTION
## Contexte

Le widget ArgoCD de Homepage sur genmachine n'avait pas de credentials — les appels à `/api/v1/applications` étaient refusés. ArgoCD utilise Authentik comme fournisseur **OIDC** (pas proxy outpost) : l'API est directement accessible avec un token ArgoCD. **Aucun SA Authentik n'est nécessaire.**

## Changements

### ArgoCD (`gitops/bootstrap/genmachine/genmachine-values.yaml`)
- Ajout du compte local `sa-homepage` avec capability `apiKey`
- Ajout RBAC `g, sa-homepage, role:readonly` (accès lecture seule aux applications)

### Homepage (`gitops/manifests/homepage/genmachine/`)
- `templates/externalsecret.yaml` (nouveau) : tire le token depuis Vault `homepage/argocd/genmachine` → secret K8s `homepage-argocd-token`
- `genmachine-values.yaml` : monte le secret comme fichier à `/app/config/secrets/argocd-token` via `volumes` + `volumeMounts` (pattern confirmé par inspection du pod — le chart fait un pass-through YAML brut)
- `templates/config.yaml` : référence le token via `{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}` (syntax Homepage v0.6.30+, doc : https://gethomepage.dev/installation/k8s/#setting-up-services)

> **Note** : approche `envFrom` non utilisée car le chart ne rend pas la clé `envFrom` dans le Deployment (confirmé : `envFrom: null` dans le pod actuel). Le montage fichier + `{{HOMEPAGE_FILE_}}` est la méthode fiable.

## Actions manuelles requises avant/après merge

**1. Après sync ArgoCD** — générer le token pour `sa-homepage` :
```sh
argocd account generate-token --account sa-homepage \
  --server argocd.talos-genmachine.fredcorp.com
```

**2. Stocker dans Vault** :
```sh
vault kv put homepage/argocd/genmachine token=<TOKEN_GENERE>
```

**3. Vérification post-sync** :
```sh
# Secret créé
kubectl get secret homepage-argocd-token -n homepage

# Fichier monté correctement
kubectl exec -n homepage <pod> -- cat /app/config/secrets/argocd-token

# Widget fonctionnel — doit retourner les apps
curl -s -H "Authorization: Bearer <TOKEN>" \
  https://argocd.talos-genmachine.fredcorp.com/api/v1/applications | jq '.items | length'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)