### PR TITLE
fix(homepage): correct HOMEPAGE_FILE_ substitution for ArgoCD token

### DIFF
--- a/gitops/manifests/homepage/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/homepage/genmachine/genmachine-values.yaml
@@ -13,6 +13,9 @@ homepage:
   rbac:
     enabled: true
 
+  env:
+    HOMEPAGE_FILE_ARGOCD_TOKEN: /app/config/secrets/argocd-token
+
   volumes:
     - name: homepage-config
       configMap:

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -154,7 +154,7 @@ data:
             widget:
               type: argocd
               url: https://argocd.talos-genmachine.fredcorp.com
-              key: "{{ "{{" }}HOMEPAGE_FILE_/app/config/secrets/argocd-token{{ "}}" }}"
+              key: "{{ "{{" }}HOMEPAGE_FILE_ARGOCD_TOKEN{{ "}}" }}"
               fields: ["apps", "outOfSync", "healthy", "degraded"]
         - AdGuard:
             href: https://adguard.talos-genmachine.fredcorp.com


### PR DESCRIPTION
## Cause racine

`{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}` ne fonctionne pas car `HOMEPAGE_FILE_` n'est pas une directive de chemin direct — c'est un préfixe d'**env var**.

**Analyse du source** (chunk `1393.js` dans le pod) :
\`\`\`javascript
let p = "HOMEPAGE_FILE_"
a = Object.entries(process.env).filter(([a]) => a.includes(p))
.forEach(([a, c]) => {
  // a = nom de l'env var  (ex: HOMEPAGE_FILE_ARGOCD_TOKEN)
  // c = valeur de l'env var = chemin du fichier à lire
  let d = readFileSync(c, "utf8")
  b = b.replaceAll(`{{${a}}}`, d)  // remplace {{HOMEPAGE_FILE_ARGOCD_TOKEN}} par le contenu
})
\`\`\`

`{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}` cherchait un env var nommé `HOMEPAGE_FILE_/app/config/secrets/argocd-token` — impossible (slashes interdits dans les noms d'env vars). La substitution ne se faisait jamais, le token JWT littéral `{{...}}` était envoyé comme Bearer token → ArgoCD retournait 401.

## Fix

1. `genmachine-values.yaml` : ajout de `env.HOMEPAGE_FILE_ARGOCD_TOKEN: /app/config/secrets/argocd-token` — l'env var pointe vers le fichier monté (chemin, pas un secret)
2. `templates/config.yaml` : template corrigé de `{{HOMEPAGE_FILE_/app/config/secrets/argocd-token}}` vers `{{HOMEPAGE_FILE_ARGOCD_TOKEN}}`

## Vérification post-merge

```sh
# Env var présente dans le pod
kubectl exec -n homepage <pod> -- env | grep HOMEPAGE_FILE_ARGOCD_TOKEN
# Doit retourner : HOMEPAGE_FILE_ARGOCD_TOKEN=/app/config/secrets/argocd-token

# Plus d'erreur 401 ArgoCD dans les logs
kubectl logs -n homepage <pod> --since=2m | grep argocd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)