### PR TITLE
fix(homepage): use extraEnv list for HOMEPAGE_FILE env var injection

### DIFF
--- a/gitops/manifests/homepage/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/homepage/genmachine/genmachine-values.yaml
@@ -13,8 +13,9 @@ homepage:
   rbac:
     enabled: true
 
-  env:
-    HOMEPAGE_FILE_ARGOCD_TOKEN: /app/config/secrets/argocd-token
+  extraEnv:
+    - name: HOMEPAGE_FILE_ARGOCD_TOKEN
+      value: /app/config/secrets/argocd-token
 
   volumes:
     - name: homepage-config


### PR DESCRIPTION
## Problème

La clé `env:` dict dans les values était silencieusement ignorée par le chart.

**Vérifié** sur le template du chart (récupéré depuis ArgoCD repo-server) :

\`\`\`yaml
# charts/homepage/templates/deployment.yaml
{{- with .Values.extraEnv }}
  {{- toYaml . | nindent 12 }}
{{- end }}
{{- with .Values.extraEnvFrom }}
envFrom:
  {{- toYaml . | nindent 12 }}
{{- end }}
\`\`\`

Le chart expose `extraEnv` (liste) et `extraEnvFrom` (liste envFrom), pas `env:` dict.

## Fix

```yaml
# Avant (ignoré)
env:
  HOMEPAGE_FILE_ARGOCD_TOKEN: /app/config/secrets/argocd-token

# Après (correct)
extraEnv:
  - name: HOMEPAGE_FILE_ARGOCD_TOKEN
    value: /app/config/secrets/argocd-token
```

## Vérification post-merge

```sh
kubectl exec -n homepage <pod> -- env | grep HOMEPAGE_FILE_ARGOCD_TOKEN
# → HOMEPAGE_FILE_ARGOCD_TOKEN=/app/config/secrets/argocd-token

kubectl logs -n homepage <pod> --since=2m | grep -i argocd
# → plus d'erreur 401
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)