### PR TITLE
feat(homepage): configure Authentik widget with API token for genmachine

### DIFF
--- a/gitops/manifests/homepage/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/homepage/genmachine/genmachine-values.yaml
@@ -16,6 +16,8 @@ homepage:
   extraEnv:
     - name: HOMEPAGE_FILE_ARGOCD_TOKEN
       value: /app/config/secrets/argocd-token
+    - name: HOMEPAGE_FILE_AUTHENTIK_TOKEN
+      value: /app/config/secrets/authentik-token
 
   volumes:
     - name: homepage-config
@@ -24,6 +26,9 @@ homepage:
     - name: homepage-argocd-token
       secret:
         secretName: homepage-argocd-token
+    - name: homepage-authentik-token
+      secret:
+        secretName: homepage-authentik-token
 
   volumeMounts:
     - mountPath: /app/config/custom.css
@@ -49,6 +54,10 @@ homepage:
       subPath: widgets.yaml
     - mountPath: /app/config/secrets/argocd-token
       name: homepage-argocd-token
+      readOnly: true
+      subPath: token
+    - mountPath: /app/config/secrets/authentik-token
+      name: homepage-authentik-token
       readOnly: true
       subPath: token
 

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -203,6 +203,7 @@ data:
               type: authentik
               url: https://authentik.talos-genmachine.fredcorp.com
               key: "{{ "{{" }}HOMEPAGE_FILE_AUTHENTIK_TOKEN{{ "}}" }}"
+              version: 2
               fields: ["users", "loginsLast24H", "failedLoginsLast24H"]
 
     - HardWare:

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -202,6 +202,7 @@ data:
             widget:
               type: authentik
               url: https://authentik.talos-genmachine.fredcorp.com
+              key: "{{ "{{" }}HOMEPAGE_FILE_AUTHENTIK_TOKEN{{ "}}" }}"
               fields: ["users", "loginsLast24H", "failedLoginsLast24H"]
 
     - HardWare:

--- a/gitops/manifests/homepage/genmachine/templates/externalsecret.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/externalsecret.yaml
@@ -16,3 +16,21 @@ spec:
       remoteRef:
         key: homepage/argocd/genmachine
         property: token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homepage-authentik-token
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: admin
+  target:
+    name: homepage-authentik-token
+    creationPolicy: Owner
+  data:
+    - secretKey: token
+      remoteRef:
+        key: homepage/authentik/genmachine
+        property: token


### PR DESCRIPTION
## Changements

Même pattern que le widget ArgoCD (vérifié et fonctionnel) :

| Fichier | Modification |
|---|---|
| `templates/externalsecret.yaml` | Ajout ExternalSecret `homepage-authentik-token` → Vault `homepage/authentik/genmachine` |
| `genmachine-values.yaml` | Ajout volume secret, volumeMount `/app/config/secrets/authentik-token`, `extraEnv HOMEPAGE_FILE_AUTHENTIK_TOKEN` |
| `templates/config.yaml` | Ajout `key: "{{HOMEPAGE_FILE_AUTHENTIK_TOKEN}}"` au widget Authentik genmachine |

## Action manuelle requise avant merge

Créer un **API token** dans Authentik (token avec intent `api`) et le stocker dans Vault.

**Étapes dans Authentik Admin UI** :
1. `https://authentik.talos-genmachine.fredcorp.com/if/admin/`
2. System → Tokens → Create
3. Identifier : `homepage-api-token`
4. User : `ixxel` (ou autre user avec permissions suffisantes)
5. Intent : **API** (pas `generic` ni `verification`)
6. Copier la clé affichée

**Stocker dans Vault** :
```sh
vault kv put homepage/authentik/genmachine token=<TOKEN_COPIE>
```

## Permissions requises pour le token

Le widget appelle :
- `GET /api/v3/core/users/?page_size=1` → count d'utilisateurs
- `GET /api/v3/events/events/per_month/?action=login` → logins
- `GET /api/v3/events/events/per_month/?action=login_failed` → échecs

L'user associé au token doit avoir accès en lecture aux users et events Authentik (superuser ou permissions explicites).

## Vérification post-merge

```sh
kubectl exec -n homepage <pod> -- env | grep HOMEPAGE_FILE_AUTHENTIK
# → HOMEPAGE_FILE_AUTHENTIK_TOKEN=/app/config/secrets/authentik-token

kubectl logs -n homepage <pod> --since=2m | grep -i authentik
# → plus d'erreur 403
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)