### PR TITLE
feat(authentik): generate Homepage API token via blueprint with dedicated SA

### DIFF
--- a/gitops/manifests/authentik/genmachine/app/genmachine-values.yaml
+++ b/gitops/manifests/authentik/genmachine/app/genmachine-values.yaml
@@ -14,6 +14,11 @@ authentik:
           secretKeyRef:
             name: adguard-creds
             key: ADGUARD_ADMIN_PWD
+      - name: HOMEPAGE_AUTHENTIK_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: homepage-authentik-api-token
+            key: HOMEPAGE_AUTHENTIK_API_TOKEN
       - name: AUTHENTIK_IXXEL_PASSWORD
         valueFrom:
           secretKeyRef:

--- a/gitops/manifests/authentik/genmachine/app/templates/extsecrets-authentik.yaml
+++ b/gitops/manifests/authentik/genmachine/app/templates/extsecrets-authentik.yaml
@@ -76,3 +76,21 @@ spec:
         metadataPolicy: None
         key: adguard/creds
         property: password
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homepage-authentik-api-token
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    name: admin
+    kind: ClusterSecretStore
+  target:
+    name: homepage-authentik-api-token
+    creationPolicy: Owner
+  data:
+    - secretKey: HOMEPAGE_AUTHENTIK_API_TOKEN
+      remoteRef:
+        key: homepage/authentik/genmachine
+        property: token

--- a/gitops/manifests/authentik/genmachine/blueprints/020-service-accounts.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/020-service-accounts.yaml
@@ -16,3 +16,15 @@ entries:
       path: goauthentik.io/service-accounts
       type: service_account
       username: sa-homarr
+  - model: authentik_core.user
+    identifiers:
+      username: sa-homepage
+    attrs:
+      is_active: true
+      name: sa-homepage
+      path: goauthentik.io/service-accounts
+      type: service_account
+      username: sa-homepage
+      user_permissions:
+        - !Find [auth.permission, [codename, view_user, content_type__app_label, authentik_core]]
+        - !Find [auth.permission, [codename, view_event, content_type__app_label, authentik_events]]

--- a/gitops/manifests/authentik/genmachine/blueprints/140-tokens.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/140-tokens.yaml
@@ -10,6 +10,6 @@ entries:
       identifier: homepage-api
     attrs:
       intent: api
-      user: !Find [authentik_core.user, [username, ixxel]]
+      user: !Find [authentik_core.user, [username, sa-homepage]]
       key: !Env HOMEPAGE_AUTHENTIK_API_TOKEN
       expiring: false

--- a/gitops/manifests/authentik/genmachine/blueprints/140-tokens.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/140-tokens.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable
+---
+version: 1
+metadata:
+  name: genmachine-tokens
+entries:
+  - model: authentik_core.token
+    identifiers:
+      identifier: homepage-api
+    attrs:
+      intent: api
+      user: !Find [authentik_core.user, [username, ixxel]]
+      key: !Env HOMEPAGE_AUTHENTIK_API_TOKEN
+      expiring: false

--- a/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
       - ./030-groups.yaml
       - ./020-service-accounts.yaml
       - ./120-properties.yaml
+      - ./140-tokens.yaml
       - ./000-flows.yaml
       - ./enrollment.yaml
       - ./010-users.yaml


### PR DESCRIPTION
## Contexte

Token pour le widget Homepage Authentik — compte de service dédié `sa-homepage` avec permissions **read-only minimales**, au lieu de `ixxel` (superuser).

## Architecture

```
Vault (homepage/authentik/genmachine.token)
    │
    ├─► ExternalSecret (authentik ns) → env var HOMEPAGE_AUTHENTIK_API_TOKEN dans le pod Authentik
    │       │
    │       └─► Blueprint 020 → crée sa-homepage (type: service_account)
    │                           permissions: view_user + view_event uniquement
    │           Blueprint 140 → crée Token Authentik lié à sa-homepage
    │                           key: !Env HOMEPAGE_AUTHENTIK_API_TOKEN
    │
    └─► ExternalSecret (homepage ns, PR #1769) → fichier monté → widget
```

## Changements

| Fichier | Modification |
|---|---|
| `blueprints/020-service-accounts.yaml` | Ajout `sa-homepage` (service_account) avec `user_permissions: [view_user, view_event]` |
| `blueprints/140-tokens.yaml` | Token lié à `sa-homepage` au lieu de `ixxel` |
| `app/templates/extsecrets-authentik.yaml` | ExternalSecret `homepage-authentik-api-token` depuis Vault |
| `app/genmachine-values.yaml` | Injection `HOMEPAGE_AUTHENTIK_API_TOKEN` dans le pod Authentik |

## Permissions assignées

Endpoint appelés par le widget (version 2, vérifiés sur l'API Authentik 2026.2) :

| Endpoint | Permission Django |
|---|---|
| `GET /api/v3/core/users/?page_size=1` | `authentik_core.view_user` |
| `GET /api/v3/events/events/volume/?action=login&history_days=1` | `authentik_events.view_event` |
| `GET /api/v3/events/events/volume/?action=login_failed&history_days=1` | `authentik_events.view_event` |

> **Note** : l'assignation via `user_permissions` dans le blueprint est probable (~80% de certitude) — les blueprints ont accès direct à l'ORM Django et `user_permissions` est un champ M2M standard sur `AbstractUser`. Si le blueprint échoue sur cette partie, les logs Authentik l'indiqueront clairement et la permission peut être assignée manuellement via l'Admin UI.

## Action manuelle unique

```sh
vault kv put homepage/authentik/genmachine token=$(openssl rand -hex 40)
```

## Dépendances

Merger avec **PR #1769** (feat/homepage-authentik-widget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)