### PR TITLE
feat(authentik): least-privilege RBAC role for Homepage widget

### DIFF
--- a/gitops/manifests/authentik/genmachine/blueprints/020-service-accounts.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/020-service-accounts.yaml
@@ -25,6 +25,5 @@ entries:
       path: goauthentik.io/service-accounts
       type: service_account
       username: sa-homepage
-      user_permissions:
-        - !Find [auth.permission, [codename, view_user, content_type__app_label, authentik_core]]
-        - !Find [auth.permission, [codename, view_event, content_type__app_label, authentik_events]]
+      roles:
+        - !Find [authentik_rbac.role, [name, homepage-readonly]]

--- a/gitops/manifests/authentik/genmachine/blueprints/135-rbac.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/135-rbac.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+# yamllint disable
+---
+version: 1
+metadata:
+  name: genmachine-rbac
+entries:
+  - model: authentik_rbac.role
+    identifiers:
+      name: homepage-readonly
+    attrs:
+      permissions:
+        - !Find [auth.permission, [codename, view_user, content_type__app_label, authentik_core]]
+        - !Find [auth.permission, [codename, view_event, content_type__app_label, authentik_events]]

--- a/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
+++ b/gitops/manifests/authentik/genmachine/blueprints/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
       - ./030-groups.yaml
       - ./020-service-accounts.yaml
       - ./120-properties.yaml
+      - ./135-rbac.yaml
       - ./140-tokens.yaml
       - ./000-flows.yaml
       - ./enrollment.yaml


### PR DESCRIPTION
## Problème

Le token Authentik pour le widget Homepage était lié à `ixxel` (superuser → accès complet). La PR précédente tentait `user_permissions` via blueprint mais ce champ n'est pas vérifié par le backend DRF d'Authentik.

## Solution

**Vérifiée sur le blueprint schema (`goauthentik.io/blueprints/schema.json`) :**
- `model_authentik_rbac.role` expose `permissions` → assignation directe de permissions au role
- `model_authentik_core.user` expose `roles` → binding user→role dans le blueprint

```yaml
# 135-rbac.yaml
- model: authentik_rbac.role
  identifiers: {name: homepage-readonly}
  attrs:
    permissions:
      - !Find [auth.permission, [codename, view_user, content_type__app_label, authentik_core]]
      - !Find [auth.permission, [codename, view_event, content_type__app_label, authentik_events]]

# 020-service-accounts.yaml
- model: authentik_core.user
  identifiers: {username: sa-homepage}
  attrs:
    type: service_account
    roles:
      - !Find [authentik_rbac.role, [name, homepage-readonly]]
```

## Permissions assignées (validées via API)

| Endpoint widget | Permission | Test |
|---|---|---|
| `GET /api/v3/core/users/?page_size=1` | `authentik_core.view_user` | 200 ✅ |
| `GET /api/v3/events/events/volume/?action=login` | `authentik_events.view_event` | 200 ✅ |
| `GET /api/v3/events/events/volume/?action=login_failed` | `authentik_events.view_event` | 200 ✅ |

Le rôle `homepage-readonly` et son binding ont été créés manuellement via l'API lors du diagnostic — le blueprint les reprendra en idempotent (`state: present`).

## Changements

| Fichier | Modification |
|---|---|
| `blueprints/135-rbac.yaml` (nouveau) | Rôle `homepage-readonly` avec `view_user` + `view_event` |
| `blueprints/020-service-accounts.yaml` | Ajout `sa-homepage` (service_account) avec `roles: [homepage-readonly]` |
| `blueprints/kustomization.yaml` | Enregistre `135-rbac.yaml` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)