### PR TITLE
fix(homepage): align volume name homepage-adguard-creds with volumeMounts

### DIFF
--- a/gitops/manifests/homepage/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/homepage/genmachine/genmachine-values.yaml
@@ -33,9 +33,9 @@ homepage:
     - name: homepage-authentik-token
       secret:
         secretName: homepage-authentik-token
-    - name: homepage-adguard-password
+    - name: homepage-adguard-creds
       secret:
-        secretName: homepage-adguard-password
+        secretName: homepage-adguard-creds
 
   volumeMounts:
     - mountPath: /app/config/custom.css


### PR DESCRIPTION
## Summary

Volume `homepage-adguard-password` (leftover from initial PR) was renamed in the ExternalSecret and volumeMounts to `homepage-adguard-creds`, but the `volumes:` entry was not updated — causing ArgoCD server-side apply dry-run failure:

```
spec.template.spec.containers[0].volumeMounts[11].name: Not found: "homepage-adguard-creds"
spec.template.spec.containers[0].volumeMounts[12].name: Not found: "homepage-adguard-creds"
```

Single change: `volumes[].name` and `volumes[].secret.secretName` → `homepage-adguard-creds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)