### PR TITLE
feat(homepage): configure Traefik widget with internal API service for genmachine

### DIFF
--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -118,7 +118,7 @@ data:
             description: Ingress Controller
             widget:
               type: traefik
-              url: https://traefik.talos-genmachine.fredcorp.com
+              url: http://traefik-api.traefik.svc.cluster.local:8080
               fields: ["routers", "services", "middleware"]
 
     - Infrastructure k0s:

--- a/gitops/manifests/traefik/genmachine/templates/service-api.yaml
+++ b/gitops/manifests/traefik/genmachine/templates/service-api.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-api
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/instance: traefik-traefik
+  ports:
+    - name: api
+      port: 8080
+      targetPort: traefik
+      protocol: TCP


### PR DESCRIPTION
## Summary

- Traefik dashboard is behind the Authentik `forwardAuth` middleware — the external URL `traefik.talos-genmachine.fredcorp.com` requires Authentik auth and cannot be used by the widget
- The Traefik API entrypoint (port 8080) has `expose: default: false` in the chart, so it is NOT included in the existing K8s LoadBalancer service
- New `service-api.yaml`: ClusterIP service `traefik-api` selecting Traefik pods (`app.kubernetes.io/instance: traefik-traefik`) and forwarding to `targetPort: traefik` (port 8080)
- No credentials needed — the API has no authentication by itself; the Authentik middleware is bypassed via internal URL

## Changes

| File | Change |
|---|---|
| `traefik/genmachine/templates/service-api.yaml` | New ClusterIP service exposing port 8080 cluster-internally |
| `homepage/genmachine/templates/config.yaml` | Widget URL → `http://traefik-api.traefik.svc.cluster.local:8080` |

## Test plan

- [ ] ArgoCD syncs `traefik-api` Service in `traefik` namespace
- [ ] ArgoCD syncs Homepage ConfigMap with new widget URL
- [ ] Homepage pod restarts → Traefik widget shows routers/services/middleware counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)