### PR TITLE
fix(traefik): enable api.insecure for Homepage widget on genmachine

### DIFF
--- a/gitops/manifests/traefik/genmachine/genmachine-values.yaml
+++ b/gitops/manifests/traefik/genmachine/genmachine-values.yaml
@@ -6,6 +6,9 @@ traefik:
     tag: v3.7.1
     pullPolicy: IfNotPresent
 
+  api:
+    insecure: true
+
   global:
     checkNewVersion: false
     sendAnonymousUsage: false


### PR DESCRIPTION
## Summary

Follow-up to #1775. The `traefik-api` ClusterIP service was correctly reaching Traefik on port 8080, but returning `404 page not found` because `api.insecure` defaults to `false` in Traefik v3.

With `insecure: false`, the API is only accessible through a properly configured router (`api@internal` via IngressRoute). Port 8080 has no routes and returns 404 for any path.

With `insecure: true`, the API is served directly on the `traefik` entrypoint (port 8080) without requiring a route — `/api/overview` and other API paths work immediately.

**Security**: `traefik-api` is a ClusterIP service not exposed externally, so enabling insecure mode only grants access to workloads inside the cluster.

## Test plan

- [ ] Traefik pod restarts after sync
- [ ] `curl http://traefik-api.traefik.svc.cluster.local:8080/api/overview` returns JSON
- [ ] Homepage Traefik widget shows routers/services/middleware counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)