### PR TITLE
feat(homepage): add Hubble, Renovate, Crossview and Komoplane service cards

### DIFF
--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -120,6 +120,11 @@ data:
               type: traefik
               url: http://traefik-api.traefik.svc.cluster.local:8080
               fields: ["routers", "services", "middleware"]
+        - Hubble:
+            href: https://hubble.talos-genmachine.fredcorp.com
+            icon: cilium.png
+            siteMonitor: https://hubble.talos-genmachine.fredcorp.com
+            description: Cilium network observability
 
     - Infrastructure k0s:
         - ArgoCD:
@@ -173,6 +178,21 @@ data:
             icon: minio.png
             siteMonitor: https://minio.talos-genmachine.fredcorp.com
             description: Storage Object server
+        - Renovate:
+            href: https://renovate-operator.talos-genmachine.fredcorp.com
+            icon: renovate.png
+            siteMonitor: https://renovate-operator.talos-genmachine.fredcorp.com
+            description: Automated dependency updates
+        - Crossview:
+            href: https://crossview.talos-genmachine.fredcorp.com
+            icon: mdi-layers-triple
+            siteMonitor: https://crossview.talos-genmachine.fredcorp.com
+            description: Crossplane UI
+        - Komoplane:
+            href: https://komoplane.talos-genmachine.fredcorp.com
+            icon: mdi-monitor-dashboard
+            siteMonitor: https://komoplane.talos-genmachine.fredcorp.com
+            description: Crossplane dashboard
 
     - Security k0s:
         - Authentik:


### PR DESCRIPTION
## Summary

Adds 4 new service cards to the genmachine Homepage dashboard. None of these tools have a dedicated Homepage widget — all are `siteMonitor`-only cards showing up/down status.

| Service | Section | URL | Auth |
|---|---|---|---|
| Hubble | Networking Talos | `hubble.talos-genmachine.fredcorp.com` | None (direct) |
| Renovate Operator | Infrastructure Talos | `renovate-operator.talos-genmachine.fredcorp.com` | None (direct) |
| Crossview | Infrastructure Talos | `crossview.talos-genmachine.fredcorp.com` | OIDC (app-level, PR #1739) |
| Komoplane | Infrastructure Talos | `komoplane.talos-genmachine.fredcorp.com` | None (direct) |

## Icons

- `renovate.png` — available in walkxcode/dashboard-icons
- `cilium.png` — available in walkxcode/dashboard-icons (used for Hubble, part of Cilium)
- `mdi-layers-triple` — MDI fallback for Crossview (no PNG in standard packs)
- `mdi-monitor-dashboard` — MDI fallback for Komoplane (no PNG in standard packs)

> If specific PNG icons become available later for Crossview/Komoplane, update the `icon:` fields.

## No credentials / no secrets required

No ExternalSecret, no volume mounts, no env vars — purely display cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)