### PR TITLE
feat(argocd/beelink): enable ApplicationSet controller for standard mode

### DIFF
--- a/gitops/bootstrap/beelink/beelink-values.yaml
+++ b/gitops/bootstrap/beelink/beelink-values.yaml
@@ -71,7 +71,7 @@ argo-cd:
           release: prometheus
 
   applicationSet:
-    enabled: false
+    enabled: true
     replicas: 1
     pdb:
       enabled: true


### PR DESCRIPTION
## Summary

Transitions beelink ArgoCD from **core mode** to **standard mode** by enabling the ApplicationSet controller.

### What is "core mode" here

Per ArgoCD docs, core mode = headless installation without the persistent HTTP API server/UI. In this codebase, `applicationSet.enabled: false` is what constitutes the "core" posture — the ApplicationSet controller is the key component differentiating standard from core.

### Change

```diff
- applicationSet:
-   enabled: false
+ applicationSet:
+   enabled: true
```

All other components (`server`, `dex`, `redis`, `controller`, `repoServer`) are already configured and remain untouched — this is the only change.

### Backwards compatibility

- All existing `Application` resources in `gitops/core/apps/beelink/` continue to work without modification
- ApplicationSet controller is **additive** — it creates a new controller deployment without removing or disrupting anything
- RBAC, OIDC (Authentik via dex), ingress, and all `configs` are unchanged
- Once the controller is running, ApplicationSets can be introduced progressively in separate PRs

### After merge

ArgoCD on beelink will deploy a new `argocd-applicationset-controller` pod. No restart of existing pods required. Rollback = flip `enabled` back to `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)