### PR TITLE
fix(argocd/beelink): add runAsUser: 1001 to dex containerSecurityContext

### DIFF
--- a/gitops/bootstrap/beelink/beelink-values.yaml
+++ b/gitops/bootstrap/beelink/beelink-values.yaml
@@ -98,6 +98,17 @@ argo-cd:
       repository: ghcr.io/dexidp/dex
       tag: v2.45.1
       imagePullPolicy: IfNotPresent
+    containerSecurityContext:
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile:
+        type: RuntimeDefault
     pdb:
       enabled: true
       maxUnavailable: 1


### PR DESCRIPTION
## Problem

```
container has runAsNonRoot and image has non-numeric user (dex),
cannot verify user is non-root
```

Kubernetes enforces `runAsNonRoot: true` (default in the ArgoCD chart) but cannot verify it when the image specifies a non-numeric username (`USER dex:dex`).

## Root cause

The dex image (`ghcr.io/dexidp/dex:v2.45.1`) declares `USER dex:dex` in its Dockerfile. Kubernetes reads the image config, sees a string username, and refuses to admit the pod because it cannot confirm `dex ≠ root` without resolving the `/etc/passwd` inside the container.

## Fix

Add explicit `runAsUser: 1001` — confirmed in the dex Dockerfile:
```dockerfile
RUN addgroup -g 1001 -S dex && adduser -u 1001 -S -G dex -D -H -s /sbin/nologin dex
```

UID 1001 ≠ 0 → satisfies `runAsNonRoot: true`. Full security context matches what genmachine already has.

## Identical fix already on genmachine

`gitops/bootstrap/genmachine/genmachine-values.yaml` already has:
```yaml
dex:
  containerSecurityContext:
    runAsUser: 1001
    runAsGroup: 1001
    runAsNonRoot: true
    ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)