### PR TITLE
fix(argocd/beelink): ignore Application .status in SSA diff for argocd-apps

### DIFF
--- a/gitops/core/apps/beelink/argocd-application.yaml
+++ b/gitops/core/apps/beelink/argocd-application.yaml
@@ -25,6 +25,11 @@ spec:
     - path: gitops/core/clusters/beelink
       repoURL: https://github.com/ixxeL-DevOps/fullstack.git
       targetRevision: main
+  ignoreDifferences:
+    - group: argoproj.io
+      kind: Application
+      jqPathExpressions:
+        - .status
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
## Problem

```
Failed to compare desired state to live state: failed to calculate diff from cache:
error calculating server side diff: serverSideDiff error: error running server side
apply in dryrun mode for resource Application/argocd-apps:
Application.argoproj.io "argocd-apps" is invalid:
[status.operationState.syncResult.revision: Required value,
 status.operationState.phase: Required value]
```

## Root cause

`argocd-apps` is self-referential: it manages `gitops/core/apps/beelink/` which contains `argocd-application.yaml` — the definition of `argocd-apps` itself.

With `ServerSideApply=true`, ArgoCD performs an SSA dry-run against the live object to compute the diff. The live `argocd-apps` Application has `status.operationState` populated by the controller with `syncResult.revision` and `phase` (both required by the CRD schema). The desired state from git has no `status` → the SSA merge produces a `status.operationState` with missing required fields → CRD validation failure.

## Fix

```yaml
ignoreDifferences:
  - group: argoproj.io
    kind: Application
    jqPathExpressions:
      - .status
```

Tells ArgoCD to exclude `.status` from the SSA diff computation for all `Application` resources managed by `argocd-apps`. `status` is runtime state never managed via git — ignoring it is always correct. `RespectIgnoreDifferences=true` is already set in syncOptions so the exclusion applies at both diff and sync time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)