### PR TITLE
fix(argocd): robustify app-of-apps sync across beelink and genmachine

### DIFF
--- a/gitops/core/apps/beelink/adguard.yaml
+++ b/gitops/core/apps/beelink/adguard.yaml
@@ -31,15 +31,15 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m

--- a/gitops/core/apps/beelink/argocd-application.yaml
+++ b/gitops/core/apps/beelink/argocd-application.yaml
@@ -31,15 +31,15 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m

--- a/gitops/core/apps/beelink/authentik.yaml
+++ b/gitops/core/apps/beelink/authentik.yaml
@@ -31,15 +31,15 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m

--- a/gitops/core/apps/beelink/cert-manager.yaml
+++ b/gitops/core/apps/beelink/cert-manager.yaml
@@ -31,15 +31,15 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m

--- a/gitops/core/apps/beelink/external-secrets.yaml
+++ b/gitops/core/apps/beelink/external-secrets.yaml
@@ -31,18 +31,18 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m
     managedNamespaceMetadata:
       labels:
         bundle.chain/inject: 'enabled'

--- a/gitops/core/apps/beelink/homarr.yaml
+++ b/gitops/core/apps/beelink/homarr.yaml
@@ -31,15 +31,15 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 4
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m

--- a/gitops/core/apps/beelink/local-path-provisioner.yaml
+++ b/gitops/core/apps/beelink/local-path-provisioner.yaml
@@ -24,15 +24,15 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m

--- a/gitops/core/apps/beelink/metallb.yaml
+++ b/gitops/core/apps/beelink/metallb.yaml
@@ -31,18 +31,18 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m
   ignoreDifferences:
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition

--- a/gitops/core/apps/beelink/stakater.yaml
+++ b/gitops/core/apps/beelink/stakater.yaml
@@ -31,15 +31,15 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m

--- a/gitops/core/apps/beelink/traefik.yaml
+++ b/gitops/core/apps/beelink/traefik.yaml
@@ -31,18 +31,18 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m
   ignoreDifferences:
     - group: traefik.io
       kind: IngressRoute

--- a/gitops/core/apps/beelink/vault.yaml
+++ b/gitops/core/apps/beelink/vault.yaml
@@ -31,18 +31,18 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m
   ignoreDifferences:
     - group: apps
       kind: StatefulSet

--- a/gitops/core/apps/beelink/wg-portal.yaml
+++ b/gitops/core/apps/beelink/wg-portal.yaml
@@ -31,18 +31,18 @@ spec:
       selfHeal: true
     syncOptions:
       - Validate=true
-      - PruneLast=false
+      - PruneLast=true
       - RespectIgnoreDifferences=true
       - Replace=false
       - ApplyOutOfSyncOnly=true
       - CreateNamespace=true
       - ServerSideApply=true
     retry:
-      limit: 2
+      limit: 6
       backoff:
-        duration: 5s
+        duration: 10s
         factor: 2
-        maxDuration: 2m
+        maxDuration: 3m
     managedNamespaceMetadata:
       labels:
         bundle.chain/inject: 'enabled'

--- a/gitops/core/apps/genmachine/argo/argocd-application.yaml
+++ b/gitops/core/apps/genmachine/argo/argocd-application.yaml
@@ -45,6 +45,15 @@ spec:
     - path: gitops/core/clusters/genmachine
       repoURL: https://github.com/ixxeL-DevOps/fullstack.git
       targetRevision: main
+  ignoreDifferences:
+    - group: argoproj.io
+      kind: ApplicationSet
+      jqPathExpressions:
+        - .status
+    - group: argoproj.io
+      kind: Application
+      jqPathExpressions:
+        - .status
   syncPolicy:
     syncOptions:
       - Validate=true


### PR DESCRIPTION
## Context

Cross-cluster audit of all ArgoCD `Application` / `ApplicationSet` files on both clusters, comparing sync options, retry policies, and ignoreDifferences patterns. Three actionable improvements identified.

---

## Change 1 — `ignoreDifferences` on genmachine `argocd-apps` (preventive)

**File:** `gitops/core/apps/genmachine/argo/argocd-application.yaml`

```yaml
ignoreDifferences:
  - group: argoproj.io
    kind: ApplicationSet
    jqPathExpressions: [.status]
  - group: argoproj.io
    kind: Application
    jqPathExpressions: [.status]
```

**Why:** Same class of error as PR #1783 (beelink). With `ServerSideApply=true`, ArgoCD performs SSA dry-run on managed resources. `ApplicationSet` and `Application` `.status` fields are runtime-only (populated by controllers, never in git). The CRD schema marks some status sub-fields as `Required`, causing SSA validation failures. PR #1783 already fixed beelink; this proactively fixes genmachine before the error manifests.

`RespectIgnoreDifferences=true` is already set → the exclusion applies at diff **and** sync time.

---

## Change 2 — `PruneLast=false` → `true` on 12 beelink Applications

**Files:** all `gitops/core/apps/beelink/*.yaml` except `argocd.yaml` (already correct)

**Why:** `PruneLast=true` ensures pruned resources are deleted **after** all other resources have been synced successfully. With `PruneLast=false`, ArgoCD may attempt to delete a resource before its dependents are updated, causing transient failures or cascading errors. Already `true` on genmachine and `beelink/argocd.yaml`.

---

## Change 3 — Retry policy alignment on beelink (`limit: 2` → `6`)

**Files:** same 12 beelink Application files + `argocd-application.yaml`

| Parameter | Before | After |
|---|---|---|
| `retry.limit` | 2 (homarr: 4) | 6 |
| `retry.backoff.duration` | 5s | 10s |
| `retry.backoff.maxDuration` | 2m | 3m |

**Why:** With `limit=2` and `maxDuration=2m`, a transient API server blip or network interruption permanently fails a sync with no further retry. `limit=6 / 3m` matches genmachine's proven settings and gives enough headroom for transient failures.

---

## Not included (separate decisions required)

| Item | Reason excluded |
|---|---|
| beelink replicas 1→2 | Cluster capacity decision |
| vault `ApplyOnly=true` | Likely intentional — Vault operator mutates resources post-apply |
| ApplicationSet on beelink | User explicitly chose to keep core mode |
| ignoreDifferences on individual ApplicationSets | Covered by global `resource.customizations.ignoreDifferences` in bootstrap configs (StatefulSet VCTs, CRD caBundle, webhook failurePolicy) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)