### PR TITLE
fix(argocd/beelink): disable controller.diff.server.side to fix SSA CRD validation

### DIFF
--- a/gitops/bootstrap/beelink/beelink-values.yaml
+++ b/gitops/bootstrap/beelink/beelink-values.yaml
@@ -263,7 +263,7 @@ argo-cd:
       controller.self.heal.timeout.seconds: 5
       controller.repo.server.timeout.seconds: 60
       controller.sync.timeout.seconds: 240 # provide Timeout for sync
-      controller.diff.server.side: 'true'
+      controller.diff.server.side: 'false'
       server.insecure: true
       server.basehref: /
       server.rootpath: ''


### PR DESCRIPTION
## Root cause

ArgoCD v3.4.2 CRD declares `syncResult.revision` as `required`. For **multi-source** Applications (using `sources[]` + `revisions[]`), ArgoCD writes `revision: ""` (empty string) — this is intentional since `revision` is a legacy single-source field.

The failure chain:

```
Controller writes revision="" to status
  → Go struct has json:"revision,omitempty"
  → SSA server-side re-serializes → "" omitted → field absent
  → Kubernetes CRD validation: syncResult.required: ['revision'] → FAIL

  status.operationState.syncResult.revision: Required value
  status.operationState.phase: Required value
```

Manual patches to `operationState` don't help because the controller immediately re-writes `revision: ""` on the next reconcile.

`ignoreDifferences` on `.status` doesn't help because it filters the **diff result** after SSA returns, but the validation error occurs **inside** Kubernetes during the SSA dry-run, before a result is returned.

## Fix

```diff
- controller.diff.server.side: 'true'
+ controller.diff.server.side: 'false'
```

Switches diff calculations from SSA dry-run to **3-way merge**. 3-way merge doesn't invoke Kubernetes CRD structural validation — it only compares YAML, bypassing the issue.

## Deployment path

The `argocd` Application (which manages `gitops/bootstrap/beelink/`) is currently **Synced/Healthy** and is unaffected by this bug. It will auto-sync this change → updates `argocd-cmd-params-cm` ConfigMap → Stakater Reloader restarts `argocd-application-controller` → new diff mode active.

## Trade-off

| | SSA diff (`true`) | 3-way diff (`false`) |
|---|---|---|
| Accuracy | Highest (server resolves field ownership) | Good (client compares YAML) |
| Validation | CRD structural validation during dry-run | No server-side validation |
| Scale suitability | Large clusters | Any scale |

For beelink (12 apps), 3-way diff is fully adequate. genmachine is unaffected and stays on `true`.

## Note

This is an ArgoCD v3.4.2 CRD bug: `syncResult.revision` should not be required when `syncResult.revisions` is used for multi-source apps. Track upstream issue for a proper fix in a future ArgoCD release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)