### PR TITLE
fix(argocd): ignore ExternalSecret nullBytePolicy on both clusters

### DIFF
--- a/gitops/bootstrap/beelink/beelink-values.yaml
+++ b/gitops/bootstrap/beelink/beelink-values.yaml
@@ -239,6 +239,10 @@ argo-cd:
       resource.customizations.ignoreDifferences.apiregistration.k8s.io_APIService: |
         jqPathExpressions:
         - .spec.insecureSkipTLSVerify
+      resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
+        jqPathExpressions:
+        - .spec.data[].remoteRef.nullBytePolicy
+        - .spec.dataFrom[].extract.nullBytePolicy
       resource.exclusions: |
         - apiGroups:
           - cilium.io

--- a/gitops/bootstrap/genmachine/genmachine-values.yaml
+++ b/gitops/bootstrap/genmachine/genmachine-values.yaml
@@ -255,6 +255,10 @@ argo-cd:
       resource.customizations.ignoreDifferences.apiregistration.k8s.io_APIService: |
         jqPathExpressions:
         - .spec.insecureSkipTLSVerify
+      resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
+        jqPathExpressions:
+        - .spec.data[].remoteRef.nullBytePolicy
+        - .spec.dataFrom[].extract.nullBytePolicy
       resource.exclusions: |
         - apiGroups:
           - cilium.io


### PR DESCRIPTION
## Problem

ExternalSecrets operator v0.9+ automatically injects `nullBytePolicy: Ignore` on `ExternalSecret` resources after creation. This field is absent from git-managed manifests → permanent ArgoCD diff on every ExternalSecret across both clusters.

Confirmed live on both clusters:
```yaml
# spec.data[].remoteRef
spec:
  data:
    - remoteRef:
        nullBytePolicy: Ignore   # injected by operator, not in git

# spec.dataFrom[].extract
spec:
  dataFrom:
    - extract:
        nullBytePolicy: Ignore   # injected by operator, not in git
```

## Fix

Added to global `resource.customizations.ignoreDifferences` in both bootstrap configs:

```yaml
resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
  jqPathExpressions:
  - .spec.data[].remoteRef.nullBytePolicy
  - .spec.dataFrom[].extract.nullBytePolicy
```

Applied to: `gitops/bootstrap/beelink/beelink-values.yaml` and `gitops/bootstrap/genmachine/genmachine-values.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)