### PR TITLE
fix(argocd): ignore ExternalSecret injected defaults and CRD annotations drift

### DIFF
--- a/gitops/bootstrap/beelink/beelink-values.yaml
+++ b/gitops/bootstrap/beelink/beelink-values.yaml
@@ -231,6 +231,7 @@ argo-cd:
       resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
         jqPathExpressions:
         - .spec.conversion.webhook.clientConfig.caBundle
+        - .metadata.annotations
       resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
         jqPathExpressions:
         - .webhooks[]?.clientConfig.caBundle
@@ -241,7 +242,13 @@ argo-cd:
         - .spec.insecureSkipTLSVerify
       resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
         jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
         - .spec.data[].remoteRef.nullBytePolicy
+        - .spec.dataFrom[].extract.conversionStrategy
+        - .spec.dataFrom[].extract.decodingStrategy
+        - .spec.dataFrom[].extract.metadataPolicy
         - .spec.dataFrom[].extract.nullBytePolicy
       resource.exclusions: |
         - apiGroups:

--- a/gitops/bootstrap/genmachine/genmachine-values.yaml
+++ b/gitops/bootstrap/genmachine/genmachine-values.yaml
@@ -247,6 +247,7 @@ argo-cd:
       resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
         jqPathExpressions:
         - .spec.conversion.webhook.clientConfig.caBundle
+        - .metadata.annotations
       resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
         jqPathExpressions:
         - .webhooks[]?.clientConfig.caBundle
@@ -257,7 +258,13 @@ argo-cd:
         - .spec.insecureSkipTLSVerify
       resource.customizations.ignoreDifferences.external-secrets.io_ExternalSecret: |
         jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+        - .spec.data[].remoteRef.metadataPolicy
         - .spec.data[].remoteRef.nullBytePolicy
+        - .spec.dataFrom[].extract.conversionStrategy
+        - .spec.dataFrom[].extract.decodingStrategy
+        - .spec.dataFrom[].extract.metadataPolicy
         - .spec.dataFrom[].extract.nullBytePolicy
       resource.exclusions: |
         - apiGroups:


### PR DESCRIPTION
## Problems

### 1. ExternalSecret operator-injected default fields

ExternalSecrets operator automatically sets these fields on all `ExternalSecret` resources after creation. They are absent from git manifests → permanent diff.

Confirmed present on both clusters in two locations:

| Field | Default value |
|---|---|
| `conversionStrategy` | `Default` |
| `decodingStrategy` | `None` or `Base64` (provider-dependent) |
| `metadataPolicy` | `None` |

Paths:
- `spec.data[].remoteRef.*`
- `spec.dataFrom[].extract.*`

Extends the existing `external-secrets.io_ExternalSecret` ignoreDifferences (from PR #1786 which covered `nullBytePolicy`) with the 3 remaining injected fields.

### 2. CRD `metadata.annotations` drift

Helm chart manifests for CRDs (Traefik, cert-manager, ExternalSecrets, etc.) do not include `metadata.annotations`. After install, CRD controllers inject `controller-gen.kubebuilder.io/version` into the live object. ArgoCD sees a permanent diff and wants to remove the annotation.

Added `.metadata.annotations` to the existing `apiextensions.k8s.io_CustomResourceDefinition` ignoreDifferences.

## Changes

Both `gitops/bootstrap/beelink/beelink-values.yaml` and `gitops/bootstrap/genmachine/genmachine-values.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)