### PR TITLE
feat(adguard/beelink): add API IngressRoute without Authentik for Homepage widget

### DIFF
--- a/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
+++ b/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
@@ -1,29 +1,26 @@
 ---
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: adguard-api-tls-cert
-spec:
-  secretName: adguard-api-tls-cert
-  issuerRef:
-    kind: ClusterIssuer
-    name: fredcorp-ca
-  commonName: adguard-api.k0s-fullstack.fredcorp.com
-  dnsNames:
-    - adguard-api.k0s-fullstack.fredcorp.com
----
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: adguard-homepage-api
+  annotations:
+    cert-manager.io/cluster-issuer: fredcorp-ca
+    cert-manager.io/common-name: adguard-api.k0s-fullstack.fredcorp.com
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - kind: Rule
-      match: Host(`adguard-api.k0s-fullstack.fredcorp.com`)
-      services:
-        - name: adguard-adguard-home-http
-          port: 80
+  ingressClassName: traefik
+  rules:
+    - host: adguard-api.k0s-fullstack.fredcorp.com
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: adguard-adguard-home-http
+                port:
+                  number: 80
   tls:
-    secretName: adguard-api-tls-cert
+    - secretName: adguard-api-tls-cert
+      hosts:
+        - adguard-api.k0s-fullstack.fredcorp.com

--- a/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
+++ b/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: adguard-api-tls-cert
+spec:
+  secretName: adguard-api-tls-cert
+  issuerRef:
+    kind: ClusterIssuer
+    name: fredcorp-ca
+  commonName: adguard-api.k0s-fullstack.fredcorp.com
+  dnsNames:
+    - adguard-api.k0s-fullstack.fredcorp.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: adguard-homepage-api
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`adguard-api.k0s-fullstack.fredcorp.com`)
+      services:
+        - name: adguard-adguard-home-http
+          port: 80
+  tls:
+    secretName: adguard-api-tls-cert

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -146,7 +146,7 @@ data:
             description: DNS resolver
             widget:
               type: adguard
-              url: https://adguard.k0s-fullstack.fredcorp.com
+              url: https://adguard-api.k0s-fullstack.fredcorp.com
               username: "{{ "{{" }}HOMEPAGE_FILE_ADGUARD_USER{{ "}}" }}"
               password: "{{ "{{" }}HOMEPAGE_FILE_ADGUARD_PASSWORD{{ "}}" }}"
               fields: ["queries", "blocked", "filtered", "latency"]


### PR DESCRIPTION
## Problem

Homepage runs on **genmachine** and requests AdGuard stats from the **beelink k0s** cluster. The external URL `adguard.k0s-fullstack.fredcorp.com` is behind the Authentik `forwardAuth` middleware — the widget receives the Authentik HTML login page instead of AdGuard JSON:

```
API Error: Invalid data
URL: https://adguard.k0s-fullstack.fredcorp.com/control/stats
Response Data: <!DOCTYPE html>... authentik ...
```

Cross-cluster internal service URLs (`adguard-adguard-home-http.adguard.svc.cluster.local`) are not reachable from genmachine — different clusters, different Kubernetes networks.

## Solution

New hostname `adguard-api.k0s-fullstack.fredcorp.com` with a dedicated `IngressRoute` that has **no Authentik middleware**. AdGuard's own HTTP basic auth handles access control (`sa-homepage` / password from Vault `adguard/creds`).

### DNS

The wildcard rewrite `*.k0s-fullstack.fredcorp.com → 192.168.1.191` (beelink Traefik LoadBalancer IP) already exists in **both** AdGuard instances (beelink and genmachine). No DNS changes required.

### Changes

| File | Change |
|---|---|
| `adguard/beelink/templates/ingressroute-homepage.yaml` | New: Certificate + IngressRoute for `adguard-api.k0s-fullstack.fredcorp.com`, no middlewares |
| `homepage/genmachine/templates/config.yaml` | Widget URL: `adguard.k0s-fullstack.fredcorp.com` → `adguard-api.k0s-fullstack.fredcorp.com` |

### Pre-requisite

`sa-homepage` user must exist in beelink AdGuard (Settings → Users) with the password stored at Vault `adguard/creds` (same secret used by the genmachine AdGuard widget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)