### PR TITLE
feat(authentik/genmachine): HA reliability improvements

### DIFF
--- a/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
+++ b/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
@@ -1,29 +1,26 @@
 ---
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: adguard-api-tls-cert
-spec:
-  secretName: adguard-api-tls-cert
-  issuerRef:
-    kind: ClusterIssuer
-    name: fredcorp-ca
-  commonName: adguard-api.k0s-fullstack.fredcorp.com
-  dnsNames:
-    - adguard-api.k0s-fullstack.fredcorp.com
----
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: adguard-homepage-api
+  annotations:
+    cert-manager.io/cluster-issuer: fredcorp-ca
+    cert-manager.io/common-name: adguard-api.k0s-fullstack.fredcorp.com
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - kind: Rule
-      match: Host(`adguard-api.k0s-fullstack.fredcorp.com`)
-      services:
-        - name: adguard-adguard-home-http
-          port: 80
+  ingressClassName: traefik
+  rules:
+    - host: adguard-api.k0s-fullstack.fredcorp.com
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: adguard-adguard-home-http
+                port:
+                  number: 80
   tls:
-    secretName: adguard-api-tls-cert
+    - secretName: adguard-api-tls-cert
+      hosts:
+        - adguard-api.k0s-fullstack.fredcorp.com

--- a/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
+++ b/gitops/manifests/adguard/beelink/templates/ingressroute-homepage.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: adguard-api-tls-cert
+spec:
+  secretName: adguard-api-tls-cert
+  issuerRef:
+    kind: ClusterIssuer
+    name: fredcorp-ca
+  commonName: adguard-api.k0s-fullstack.fredcorp.com
+  dnsNames:
+    - adguard-api.k0s-fullstack.fredcorp.com
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: adguard-homepage-api
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`adguard-api.k0s-fullstack.fredcorp.com`)
+      services:
+        - name: adguard-adguard-home-http
+          port: 80
+  tls:
+    secretName: adguard-api-tls-cert

--- a/gitops/manifests/authentik/genmachine/app/genmachine-values.yaml
+++ b/gitops/manifests/authentik/genmachine/app/genmachine-values.yaml
@@ -60,6 +60,40 @@ authentik:
       password: file:///pgsql-creds/password
 
   server:
+    replicas: 2
+    deploymentStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    pdb:
+      enabled: true
+      minAvailable: 1
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: authentik
+                  app.kubernetes.io/component: server
+              topologyKey: kubernetes.io/hostname
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: authentik
+            app.kubernetes.io/component: server
     ingress:
       enabled: true
       ingressClassName: traefik
@@ -78,6 +112,42 @@ authentik:
       # -- uses `server.service.servicePortHttps` instead of `server.service.servicePortHttp`
       https: false
 
+  worker:
+    replicas: 2
+    deploymentStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    pdb:
+      enabled: true
+      minAvailable: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: authentik
+                  app.kubernetes.io/component: worker
+              topologyKey: kubernetes.io/hostname
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: authentik
+            app.kubernetes.io/component: worker
+
   postgresql:
     enabled: true
     image:
@@ -92,14 +162,3 @@ authentik:
         existingClaim: pvc-authentik-pgsql-data
         storageClass: proxmox-retain
         size: 8Gi
-  redis:
-    enabled: true
-    master:
-      persistence:
-        enabled: false
-        sizeLimit: ''
-        path: /data
-        storageClass: nfs-csi-delete
-        accessModes:
-          - ReadWriteOnce
-        size: 7Gi

--- a/gitops/manifests/homepage/genmachine/templates/config.yaml
+++ b/gitops/manifests/homepage/genmachine/templates/config.yaml
@@ -146,7 +146,7 @@ data:
             description: DNS resolver
             widget:
               type: adguard
-              url: https://adguard.k0s-fullstack.fredcorp.com
+              url: https://adguard-api.k0s-fullstack.fredcorp.com
               username: "{{ "{{" }}HOMEPAGE_FILE_ADGUARD_USER{{ "}}" }}"
               password: "{{ "{{" }}HOMEPAGE_FILE_ADGUARD_PASSWORD{{ "}}" }}"
               fields: ["queries", "blocked", "filtered", "latency"]


### PR DESCRIPTION
## Summary

- Scale **server** and **worker** to 2 replicas for redundancy during node eviction/rollouts
- Add **PodDisruptionBudget** (`minAvailable: 1`) on both server and worker — prevents eviction from taking the last pod
- Set **RollingUpdate** strategy with `maxUnavailable: 0` / `maxSurge: 1` — zero-downtime deploys
- Add **soft pod anti-affinity** — prefer scheduling server/worker pods on different nodes
- Add **topologySpreadConstraints** (`ScheduleAnyway`) — best-effort spread across nodes
- Set **resource requests/limits** for server (`200m/512Mi` → `1000m/1Gi`) and worker (`100m/256Mi` → `500m/512Mi`)
- **Remove dead `redis:` config** — chart 2026.x has no redis subchart, this block had no effect

## Notes

- Embedded outpost runs within server pods: scaling to 2 replicas automatically gives 2 outpost instances
- PostgreSQL stays on embedded chart (no CNPG migration)
- Soft affinity: pods are spread when possible but scheduling is not blocked if only one node is available

## Test plan

- [ ] ArgoCD syncs cleanly on genmachine
- [ ] `kubectl get pods -n authentik` shows 2 server + 2 worker pods on different nodes
- [ ] `kubectl get pdb -n authentik` shows 2 PDBs with ALLOWED DISRUPTIONS = 1
- [ ] Authentik UI accessible at https://authentik.talos-genmachine.fredcorp.com
- [ ] Drain a node: verify service stays up on remaining pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)